### PR TITLE
Inicializa /dados do Solr quando tem volume mapeado

### DIFF
--- a/containers/solr-9.4.0/assets/command.sh
+++ b/containers/solr-9.4.0/assets/command.sh
@@ -1,3 +1,10 @@
 #!/usr/bin/env sh
 
+if [ -z "$( ls -A '/dados' )" ]; then
+      echo "O diretorio /dados está vazio. Vamos inicializa-lo copiando o conteúdo disponível em /dados-modelo"
+      cp -R /dados-modelo/* /dados/
+else
+      echo "O diretorio /dados já possui conteúdo. Não é necessário inicializa-lo"
+fi
+
 /opt/solr/bin/solr -p 8983 -f

--- a/containers/solr-9.4.0/assets/solr9.4.0sei/sei-solr-9.4.0.sh
+++ b/containers/solr-9.4.0/assets/solr9.4.0sei/sei-solr-9.4.0.sh
@@ -40,9 +40,14 @@ mkdir -v /dados/sei-protocolos/conteudo
 mkdir -v /dados/sei-bases-conhecimento/conteudo
 mkdir -v /dados/sei-publicacoes/conteudo
 
+# Copia o conteudo modelo para o diretório /dados-modelo
+# Util para inicializar o diretório /dados quando mapeando um volume vazio em /dados
+cp -Rfv /dados /dados-modelo
+
 cp -f /tmp/security.json /opt/solr/server/solr/security.json
 
 chown -R solr.solr /dados
+chown -R solr.solr /dados-modelo
 chown -R solr.solr /opt/solr/
 
 cp solr.service /etc/systemd/system/solr.service

--- a/containers/solr-9.6.1/assets/command.sh
+++ b/containers/solr-9.6.1/assets/command.sh
@@ -1,3 +1,10 @@
 #!/usr/bin/env sh
 
+if [ -z "$( ls -A '/dados' )" ]; then
+      echo "O diretorio /dados está vazio. Vamos inicializa-lo copiando o conteúdo disponível em /dados-modelo"
+      cp -R /dados-modelo/* /dados/
+else
+      echo "O diretorio /dados já possui conteúdo. Não é necessário inicializa-lo"
+fi
+
 /opt/solr/bin/solr -p 8983 -f

--- a/containers/solr-9.6.1/assets/solr9.6.1sei/sei-solr-9.6.1.sh
+++ b/containers/solr-9.6.1/assets/solr9.6.1sei/sei-solr-9.6.1.sh
@@ -43,9 +43,14 @@ mkdir -v /dados/sei-protocolos/conteudo
 mkdir -v /dados/sei-bases-conhecimento/conteudo
 mkdir -v /dados/sei-publicacoes/conteudo
 
+# Copia o conteudo modelo para o diretório /dados-modelo
+# Util para inicializar o diretório /dados quando mapeando um volume vazio em /dados
+cp -Rfv /dados /dados-modelo
+
 cp -f /tmp/security.json /opt/solr/server/solr/security.json
 
 chown -R solr.solr /dados
+chown -R solr.solr /dados-modelo
 chown -R solr.solr /opt/solr/
 
 cp solr.service /etc/systemd/system/solr.service

--- a/containers/solr/assets/command.sh
+++ b/containers/solr/assets/command.sh
@@ -1,3 +1,10 @@
 #!/usr/bin/env sh
 
+if [ -z "$( ls -A '/dados' )" ]; then
+      echo "O diretorio /dados está vazio. Vamos inicializa-lo copiando o conteúdo disponível em /dados-modelo"
+      cp -R /dados-modelo/* /dados/
+else
+      echo "O diretorio /dados já possui conteúdo. Não é necessário inicializa-lo"
+fi
+
 /opt/solr/bin/solr start -f -force -p 8983

--- a/containers/solr/assets/solr8sei/sei-solr-8.2.0.sh
+++ b/containers/solr/assets/solr8sei/sei-solr-8.2.0.sh
@@ -39,7 +39,12 @@ mkdir -v /dados/sei-protocolos/conteudo
 mkdir -v /dados/sei-bases-conhecimento/conteudo
 mkdir -v /dados/sei-publicacoes/conteudo
 
+# Copia o conteudo modelo para o diretório /dados-modelo
+# Util para inicializar o diretório /dados quando mapeando um volume vazio em /dados
+cp -Rfv /dados /dados-modelo
+
 chown -R solr.solr /dados
+chown -R solr.solr /dados-modelo
 chown -R solr.solr /opt/solr/
 
 cp solr.service /etc/systemd/system/solr.service


### PR DESCRIPTION
Da forma como está hoje, quando o Solr é iniciado com um volume mepado para `/dados`, o diretório fica vazio.

Este Pull Request cria uma cópia de `/dados` em `/dados-modelo`, e duranta a inicialização do container, caso o diretório `/dados` esteja vazio, o conteúdo de `/dados-modelo` é copiado para dentro de `/dados`.  
Isso faz com que o volume vazio seja corretamente inicializado.

Caso o diretório `/dados` já tenha conteúdo, nenhuma cópia é feita.