### PR TITLE
solr-9.6.1 set -XX:MaxRAMPercentage=80

### DIFF
--- a/containers/solr-9.6.1/assets/install.sh
+++ b/containers/solr-9.6.1/assets/install.sh
@@ -25,6 +25,9 @@ cd /tmp
 /tmp/sei-solr-9.6.1.sh
 
 echo "" >> /opt/solr/bin/solr.in.sh
+## https://developers.redhat.com/articles/2024/03/14/how-use-java-container-awareness-openshift-4#openshift_container_platform_limits_versus_requests
+## https://developers.redhat.com/articles/2022/04/19/java-17-whats-new-openjdks-container-awareness#tuning_defaults_for_containers
+echo 'SOLR_JAVA_MEM="-XX:MaxRAMPercentage=80"' >> /opt/solr/bin/solr.in.sh
 echo 'SOLR_OPTS="$SOLR_OPTS -Dsolr.allowPaths=/dados"' >> /opt/solr/bin/solr.in.sh
 echo 'SOLR_JETTY_HOST="0.0.0.0"' >> /opt/solr/bin/solr.in.sh
 


### PR DESCRIPTION
Quando o OpenJDK 17 é instalado com o comando `dnf -y install java-17-openjdk` em uma imagem base `rocky93`, a configuração padrão fica com `-XX:MaxRAMPercentage=25`, para usar no máximo 25% da memória disponível. Ou seja, mesmo que um container tenha resource.limit.memory 30Gb a JVM só poderá utilizar no máximo 7,5Gb (25%).

Este Pull Request altera para `-XX:MaxRAMPercentage=80`, que é o default para as mais recentes imagens docker openjdk.

Mais informações nos artigos abaixo:
- https://developers.redhat.com/articles/2024/03/14/how-use-java-container-awareness-openshift-4#openshift_container_platform_limits_versus_requests
- https://developers.redhat.com/articles/2022/04/19/java-17-whats-new-openjdks-container-awareness#tuning_defaults_for_containers