### PR TITLE
solr -verbose script

### DIFF
--- a/containers/solr-9.6.1/assets/command.sh
+++ b/containers/solr-9.6.1/assets/command.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-/opt/solr/bin/solr -p 8983 -f
+/opt/solr/bin/solr -p 8983 -f -verbose


### PR DESCRIPTION
Adiciona a opção `-verbose` ao comando `solr`. Isso faz que que o script `/opt/solr/bin/solr` rode em modo verboso, imprimindo informações úteis como as do exemplo abaixo.  
Obs: essa opção não alterar o log level, que permanece como está.

```
Using Solr root directory: /opt/solr
Using Java: java
openjdk version "17.0.18" 2026-01-20 LTS
OpenJDK Runtime Environment (Red_Hat-17.0.18.0.8-1) (build 17.0.18+8-LTS)
OpenJDK 64-Bit Server VM (Red_Hat-17.0.18.0.8-1) (build 17.0.18+8-LTS, mixed mode, sharing)

Starting Solr using the following settings:
JAVA = java
SOLR_SERVER_DIR = /opt/solr/server
SOLR_HOME = /opt/solr/server/solr
SOLR_HOST =
SOLR_PORT = 8983
STOP_PORT = 7983
JAVA_MEM_OPTS = -XX:MaxRAMPercentage=80
GC_TUNE = -XX:+UseG1GC -XX:+PerfDisableSharedMem -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=250 -XX:+UseLargePages -XX:+AlwaysPreTouch -XX:+ExplicitGCInvokesConcurrent
GC_LOG_OPTS = -Xlog:gc*:file=/opt/solr/server/logs/solr_gc.log:time,uptime:filecount=9,filesize=20M
SOLR_TIMEZONE = UTC
SOLR_OPTS (USER) = -Dsolr.allowPaths=/dados
SOLR_OPTS (SCRIPT) = -Dsolr.jetty.host=0.0.0.0 -Xss256k
```