### PR TITLE
docs: adiciona documentação técnica completa do projeto

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ No entanto, recomendamos usar a branch main pois será ela que vai receber novas
 
 O SEI-Docker é o projeto disponibilizado para provisionamento de ambientes do SEI usando a tecnologia docker e os orquestradores docker-compose, cattle ou kubernetes.
 
+## Documentação
+
+Para documentação técnica detalhada do projeto, consulte a pasta [docs/](docs/README.md). Lá você encontra:
+
+- Arquitetura e diagrama de serviços
+- Referência completa dos 44+ containers Docker
+- Referência das 230+ variáveis de ambiente
+- Guia unificado de instalação, configuração e uso
+- Orquestração com Docker Compose e Kubernetes
+- Configuração do ambiente de desenvolvimento
+- Testes automatizados
+
 ## Para quem
 
 O projeto atende a qualquer dos profissionais que desejem subir uma instância do SEI entre eles:

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Documentacao tecnica completa do projeto **SEI-Docker**, solucao de Infraestrutu
 
 | Documento | Descricao |
 |-----------|-----------|
+| [Guia de Uso](guia-de-uso.md) | **Comece aqui!** Guia completo de instalacao, configuracao e uso (dev + infra + containers) |
 | [Arquitetura](arquitetura.md) | Visao geral da arquitetura, camadas, fluxo de dados e diagrama de servicos |
 | [Containers](containers.md) | Detalhamento tecnico de cada imagem Docker: base, aplicacao, banco de dados, servicos auxiliares |
 | [Variaveis de Ambiente](variaveis-ambiente.md) | Referencia completa das 230+ variaveis de ambiente organizadas por categoria |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,21 +1,21 @@
-# Documentacao Tecnica - SEI-Docker
+# Documentação Técnica - SEI-Docker
 
-Documentacao tecnica completa do projeto **SEI-Docker**, solucao de Infraestrutura como Codigo para provisionamento do Sistema Eletronico de Informacoes (SEI) em ambientes de Desenvolvimento, Teste e Homologacao (DTH).
+Documentação técnica completa do projeto **SEI-Docker**, solução de Infraestrutura como Código para provisionamento do Sistema Eletrônico de Informações (SEI) em ambientes de Desenvolvimento, Teste e Homologação (DTH).
 
-**Versao do projeto:** 3.6.11
+**Versão do projeto:** 3.6.11
 
 ---
 
-## Indice
+## Índice
 
-| Documento | Descricao |
+| Documento | Descrição |
 |-----------|-----------|
-| [Guia de Uso](guia-de-uso.md) | **Comece aqui!** Guia completo de instalacao, configuracao e uso (dev + infra + containers) |
-| [Arquitetura](arquitetura.md) | Visao geral da arquitetura, camadas, fluxo de dados e diagrama de servicos |
-| [Containers](containers.md) | Detalhamento tecnico de cada imagem Docker: base, aplicacao, banco de dados, servicos auxiliares |
-| [Variaveis de Ambiente](variaveis-ambiente.md) | Referencia completa das 230+ variaveis de ambiente organizadas por categoria |
-| [Orquestracao e Deploy](orquestracao.md) | Docker Compose, Kubernetes, Rancher Cattle, Makefiles e automacao |
-| [Ambiente de Desenvolvimento](desenvolvimento.md) | Configuracao do ambiente dev com XDebug, montagem de fontes e debug |
+| [Guia de Uso](guia-de-uso.md) | **Comece aqui!** Guia completo de instalação, configuração e uso (dev + infra + containers) |
+| [Arquitetura](arquitetura.md) | Visão geral da arquitetura, camadas, fluxo de dados e diagrama de serviços |
+| [Containers](containers.md) | Detalhamento técnico de cada imagem Docker: base, aplicação, banco de dados, serviços auxiliares |
+| [Variáveis de Ambiente](variaveis-ambiente.md) | Referência completa das 230+ variáveis de ambiente organizadas por categoria |
+| [Orquestração e Deploy](orquestracao.md) | Docker Compose, Kubernetes, Rancher Cattle, Makefiles e automação |
+| [Ambiente de Desenvolvimento](desenvolvimento.md) | Configuração do ambiente dev com XDebug, montagem de fontes e debug |
 | [Testes](testes.md) | Infraestrutura de testes: containers, infraestrutura, Selenium e CI/CD |
 
 ---
@@ -25,10 +25,10 @@ Documentacao tecnica completa do projeto **SEI-Docker**, solucao de Infraestrutu
 ```
 sei-docker/
 ├── containers/                  # Receitas de build das imagens Docker (44 imagens)
-│   ├── Makefile                 # Automacao de build/push/erase
-│   ├── envcontainers.env.modelo # Template de configuracao de build
-│   ├── app/                     # Containers da aplicacao PHP 7 (legado)
-│   ├── app-php8/                # Containers da aplicacao PHP 8 (atual)
+│   ├── Makefile                 # Automação de build/push/erase
+│   ├── envcontainers.env.modelo # Template de configuração de build
+│   ├── app/                     # Containers da aplicação PHP 7 (legado)
+│   ├── app-php8/                # Containers da aplicação PHP 8 (atual)
 │   ├── databases/               # Containers de banco de dados
 │   │   ├── mariadb-*/           # MariaDB 10.5 (SEI 4.0, 4.1, 5.0)
 │   │   ├── mysql8-*/            # MySQL 8 (SEI 4.1, 5.0)
@@ -38,30 +38,30 @@ sei-docker/
 │   ├── solr*/                   # Apache Solr (8.2, 9.4, 9.6)
 │   ├── jod*/                    # JOD Converter (legado + 4.4.8)
 │   ├── traefik/                 # Load balancer Traefik
-│   ├── openldap/                # Servico de diretorio LDAP
+│   ├── openldap/                # Serviço de diretório LDAP
 │   ├── memcached/               # Cache
 │   ├── mailcatcher/             # Captura de e-mails
 │   └── tests/                   # Testes dos containers
 │
 ├── dev/                         # Ambiente de desenvolvimento
-│   ├── Makefile                 # Automacao dev (up, down, config, update)
-│   ├── docker-compose.yml       # Orquestracao simplificada
-│   ├── envs/                    # Templates de ambiente por banco/versao
+│   ├── Makefile                 # Automação dev (up, down, config, update)
+│   ├── docker-compose.yml       # Orquestração simplificada
+│   ├── envs/                    # Templates de ambiente por banco/versão
 │   └── tests/                   # Testes funcionais (Selenium)
 │
 ├── infra/                       # Infraestrutura completa (DTH)
-│   ├── Makefile                 # Automacao completa (setup, run, scale, k8s)
-│   ├── envlocal.env             # Configuracao principal (100+ variaveis)
-│   ├── envlocal-example-*.env   # Exemplos por banco/versao
-│   ├── orquestrators/           # Templates de orquestracao
+│   ├── Makefile                 # Automação completa (setup, run, scale, k8s)
+│   ├── envlocal.env             # Configuração principal (100+ variáveis)
+│   ├── envlocal-example-*.env   # Exemplos por banco/versão
+│   ├── orquestrators/           # Templates de orquestração
 │   │   ├── docker-compose/      # Docker Compose
 │   │   ├── rancher-kubernetes/  # Kubernetes
 │   │   └── rancher-cattle/      # Rancher Cattle (legado)
-│   ├── tests/                   # Testes de integracao
-│   ├── docs/                    # Documentacao original do infra
+│   ├── tests/                   # Testes de integração
+│   ├── docs/                    # Documentação original do infra
 │   └── jenkins/                 # Placeholder CI/CD
 │
-└── docs/                        # Documentacao tecnica (este diretorio)
+└── docs/                        # Documentação técnica (este diretório)
 ```
 
 ---
@@ -69,14 +69,14 @@ sei-docker/
 ## Requisitos
 
 - Docker Engine 20+
-- Docker Compose v2+ (ou v1 com hifen)
-- Codigo-fonte do SEI (obtido separadamente)
+- Docker Compose v2+ (ou v1 com hífen)
+- Código-fonte do SEI (obtido separadamente)
 - GNU Make
 - curl (para health checks)
 
 ---
 
-## Links Rapidos
+## Links Rápidos
 
 - **Subir ambiente dev:** `cd dev && make up`
 - **Subir infraestrutura:** `cd infra && make setup`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,83 @@
+# Documentacao Tecnica - SEI-Docker
+
+Documentacao tecnica completa do projeto **SEI-Docker**, solucao de Infraestrutura como Codigo para provisionamento do Sistema Eletronico de Informacoes (SEI) em ambientes de Desenvolvimento, Teste e Homologacao (DTH).
+
+**Versao do projeto:** 3.6.11
+
+---
+
+## Indice
+
+| Documento | Descricao |
+|-----------|-----------|
+| [Arquitetura](arquitetura.md) | Visao geral da arquitetura, camadas, fluxo de dados e diagrama de servicos |
+| [Containers](containers.md) | Detalhamento tecnico de cada imagem Docker: base, aplicacao, banco de dados, servicos auxiliares |
+| [Variaveis de Ambiente](variaveis-ambiente.md) | Referencia completa das 230+ variaveis de ambiente organizadas por categoria |
+| [Orquestracao e Deploy](orquestracao.md) | Docker Compose, Kubernetes, Rancher Cattle, Makefiles e automacao |
+| [Ambiente de Desenvolvimento](desenvolvimento.md) | Configuracao do ambiente dev com XDebug, montagem de fontes e debug |
+| [Testes](testes.md) | Infraestrutura de testes: containers, infraestrutura, Selenium e CI/CD |
+
+---
+
+## Estrutura do Projeto
+
+```
+sei-docker/
+├── containers/                  # Receitas de build das imagens Docker (44 imagens)
+│   ├── Makefile                 # Automacao de build/push/erase
+│   ├── envcontainers.env.modelo # Template de configuracao de build
+│   ├── app/                     # Containers da aplicacao PHP 7 (legado)
+│   ├── app-php8/                # Containers da aplicacao PHP 8 (atual)
+│   ├── databases/               # Containers de banco de dados
+│   │   ├── mariadb-*/           # MariaDB 10.5 (SEI 4.0, 4.1, 5.0)
+│   │   ├── mysql8-*/            # MySQL 8 (SEI 4.1, 5.0)
+│   │   ├── oracle-*/            # Oracle 11g (SEI 4.0, 4.1, 5.0)
+│   │   ├── postgres-*/          # PostgreSQL 15 (SEI 4.0, 4.1, 5.0)
+│   │   └── sqlserver-*/         # SQL Server 2019 (SEI 4.0, 4.1, 5.0)
+│   ├── solr*/                   # Apache Solr (8.2, 9.4, 9.6)
+│   ├── jod*/                    # JOD Converter (legado + 4.4.8)
+│   ├── traefik/                 # Load balancer Traefik
+│   ├── openldap/                # Servico de diretorio LDAP
+│   ├── memcached/               # Cache
+│   ├── mailcatcher/             # Captura de e-mails
+│   └── tests/                   # Testes dos containers
+│
+├── dev/                         # Ambiente de desenvolvimento
+│   ├── Makefile                 # Automacao dev (up, down, config, update)
+│   ├── docker-compose.yml       # Orquestracao simplificada
+│   ├── envs/                    # Templates de ambiente por banco/versao
+│   └── tests/                   # Testes funcionais (Selenium)
+│
+├── infra/                       # Infraestrutura completa (DTH)
+│   ├── Makefile                 # Automacao completa (setup, run, scale, k8s)
+│   ├── envlocal.env             # Configuracao principal (100+ variaveis)
+│   ├── envlocal-example-*.env   # Exemplos por banco/versao
+│   ├── orquestrators/           # Templates de orquestracao
+│   │   ├── docker-compose/      # Docker Compose
+│   │   ├── rancher-kubernetes/  # Kubernetes
+│   │   └── rancher-cattle/      # Rancher Cattle (legado)
+│   ├── tests/                   # Testes de integracao
+│   ├── docs/                    # Documentacao original do infra
+│   └── jenkins/                 # Placeholder CI/CD
+│
+└── docs/                        # Documentacao tecnica (este diretorio)
+```
+
+---
+
+## Requisitos
+
+- Docker Engine 20+
+- Docker Compose v2+ (ou v1 com hifen)
+- Codigo-fonte do SEI (obtido separadamente)
+- GNU Make
+- curl (para health checks)
+
+---
+
+## Links Rapidos
+
+- **Subir ambiente dev:** `cd dev && make up`
+- **Subir infraestrutura:** `cd infra && make setup`
+- **Build de containers:** `cd containers && make build-conteiners`
+- **Rodar testes:** `cd infra/tests && make test_lineup_completa`

--- a/docs/arquitetura.md
+++ b/docs/arquitetura.md
@@ -1,16 +1,16 @@
-# Arquitetura Tecnica - SEI-Docker
+# Arquitetura Técnica - SEI-Docker
 
-## Visao Geral
+## Visão Geral
 
-O SEI-Docker implementa uma arquitetura de microservicos baseada em containers Docker para o Sistema Eletronico de Informacoes (SEI). O projeto e destinado exclusivamente a ambientes de **Desenvolvimento, Teste e Homologacao (DTH)**, nao sendo recomendado para producao.
+O SEI-Docker implementa uma arquitetura de microsserviços baseada em containers Docker para o Sistema Eletrônico de Informações (SEI). O projeto é destinado exclusivamente a ambientes de **Desenvolvimento, Teste e Homologação (DTH)**, não sendo recomendado para produção.
 
 ---
 
-## Diagrama de Servicos
+## Diagrama de Serviços
 
 ```
                          ┌─────────────────────────┐
-                         │     Usuario / Browser    │
+                         │     Usuário / Browser    │
                          └────────────┬────────────┘
                                       │
                               ┌───────▼───────┐
@@ -46,62 +46,62 @@ O SEI-Docker implementa uma arquitetura de microservicos baseada em containers D
 
 ### 1. Camada de Entrada (Load Balancer)
 
-| Componente | Imagem | Funcao |
+| Componente | Imagem | Função |
 |------------|--------|--------|
-| **Traefik** | `traefik:v3.6.7` | Reverse proxy, balanceamento de carga, terminacao TLS, roteamento por labels |
+| **Traefik** | `traefik:v3.6.7` | Reverse proxy, balanceamento de carga, terminação TLS, roteamento por labels |
 
-- Substituiu o HAProxy na versao 3.0.0
+- Substituiu o HAProxy na versão 3.0.0
 - Suporta HTTP e HTTPS com certificados auto-gerados ou customizados
-- Dashboard administrativo disponivel em `/traefik`
+- Dashboard administrativo disponível em `/traefik`
 - Escalonamento horizontal transparente via Docker labels
 
-### 2. Camada de Aplicacao
+### 2. Camada de Aplicação
 
-| Componente | Imagem Base | Funcao |
+| Componente | Imagem Base | Função |
 |------------|-------------|--------|
-| **App (SEI/SIP)** | Rocky Linux 9.3 + PHP 8.2 | Aplicacao web principal |
-| **App Atualizador** | Mesma imagem do App | Executa atualizacoes de versao e instalacao de modulos |
-| **App Agendador** | Extensao do App | Jobs em background via Cron, Gearman e Supervisor |
-| **App Dev** | Extensao do App Base | Ambiente de desenvolvimento com XDebug |
+| **App (SEI/SIP)** | Rocky Linux 9.3 + PHP 8.2 | Aplicação web principal |
+| **App Atualizador** | Mesma imagem do App | Executa atualizações de versão e instalação de módulos |
+| **App Agendador** | Extensão do App | Jobs em background via Cron, Gearman e Supervisor |
+| **App Dev** | Extensão do App Base | Ambiente de desenvolvimento com XDebug |
 
-**Stack da aplicacao:**
+**Stack da aplicação:**
 - Apache 2.4 + mod_ssl + PHP-FPM
-- PHP 8.2 com extensoes: bcmath, gd, gmp, imap, intl, ldap, mbstring, pdo, memcache, memcached, gearman
-- Java 1.8 (conversao de documentos)
+- PHP 8.2 com extensões: bcmath, gd, gmp, imap, intl, ldap, mbstring, pdo, memcache, memcached, gearman
+- Java 1.8 (conversão de documentos)
 - Locale: pt_BR.ISO-8859-1
 
 ### 3. Camada de Dados
 
-| Componente | Versao | Porta | Observacao |
+| Componente | Versão | Porta | Observação |
 |------------|--------|-------|------------|
 | **MariaDB** | 10.5 | 3306 | Fork do MySQL, suporte completo |
-| **MySQL** | 8.0.21 | 3306 | Banco padrao para dev |
-| **PostgreSQL** | 15 | 5432 | Autenticacao SCRAM-SHA-256 |
-| **Oracle** | 11g XE | 1521 | Versao Express |
-| **SQL Server** | 2019 | 1433 | Experimental, nao para producao |
+| **MySQL** | 8.0.21 | 3306 | Banco padrão para dev |
+| **PostgreSQL** | 15 | 5432 | Autenticação SCRAM-SHA-256 |
+| **Oracle** | 11g XE | 1521 | Versão Express |
+| **SQL Server** | 2019 | 1433 | Experimental, não para produção |
 
-Cada banco de dados possui imagens pre-populadas com o schema do SEI para as versoes 4.0, 4.1 e 5.0.
+Cada banco de dados possui imagens pré-populadas com o schema do SEI para as versões 4.0, 4.1 e 5.0.
 
-### 4. Camada de Servicos Auxiliares
+### 4. Camada de Serviços Auxiliares
 
-| Componente | Imagem | Funcao |
+| Componente | Imagem | Função |
 |------------|--------|--------|
-| **Memcached** | `memcached:latest` | Cache de sessoes PHP e cache da aplicacao |
-| **Apache Solr** | 8.2.0 / 9.4.0 / 9.6.1 | Indexacao e busca full-text de documentos |
-| **JOD Converter** | 4.4.8 (Alpine) | Conversao de documentos via LibreOffice |
-| **OpenLDAP** | osixia/openldap:1.2.2 | Autenticacao e diretorio de usuarios |
+| **Memcached** | `memcached:latest` | Cache de sessões PHP e cache da aplicação |
+| **Apache Solr** | 8.2.0 / 9.4.0 / 9.6.1 | Indexação e busca full-text de documentos |
+| **JOD Converter** | 4.4.8 (Alpine) | Conversão de documentos via LibreOffice |
+| **OpenLDAP** | osixia/openldap:1.2.2 | Autenticação e diretório de usuários |
 | **MailCatcher** | schickling/mailcatcher | Captura de e-mails em ambiente de teste |
 
-### 5. Camada de Administracao (opcional)
+### 5. Camada de Administração (opcional)
 
-| Interface | URL | Funcao |
+| Interface | URL | Função |
 |-----------|-----|--------|
 | **Traefik Dashboard** | `/traefik` | Monitoramento do load balancer |
-| **Adminer** | `/dbadmin` | Administracao do banco de dados |
-| **phpLDAPadmin** | `/phpldapadmin` | Administracao do LDAP |
-| **phpMemcachedAdmin** | `/memcachedadmin` | Administracao do cache |
-| **Solr Admin** | `/solr` | Administracao da busca |
-| **MailCatcher** | `/mailadmin` | Visualizacao de e-mails capturados |
+| **Adminer** | `/dbadmin` | Administração do banco de dados |
+| **phpLDAPadmin** | `/phpldapadmin` | Administração do LDAP |
+| **phpMemcachedAdmin** | `/memcachedadmin` | Administração do cache |
+| **Solr Admin** | `/solr` | Administração da busca |
+| **MailCatcher** | `/mailadmin` | Visualização de e-mails capturados |
 
 ---
 
@@ -136,34 +136,34 @@ traefik:v3.6.7                 osixia/openldap:1.2.2
 
 ---
 
-## Fluxo de Inicializacao
+## Fluxo de Inicialização
 
 ### Infraestrutura (infra/)
 
 ```
 make setup
     │
-    ├── check-version-compatibility    # Valida versao do fonte vs containers
+    ├── check-version-compatibility    # Valida versão do fonte vs containers
     ├── criar_volumes                  # Cria volumes Docker persistentes
-    │   ├── criar_volume_fontes        # Codigo-fonte do SEI
+    │   ├── criar_volume_fontes        # Código-fonte do SEI
     │   ├── criar_volume_certs         # Certificados SSL
     │   ├── criar_volume_banco         # Dados do banco
     │   ├── criar_volume_arquivos_externos  # Anexos
-    │   ├── criar_volume_solr          # Indices de busca
+    │   ├── criar_volume_solr          # Índices de busca
     │   ├── criar_volume_openldap      # Dados LDAP
-    │   └── criar_volume_controlador_instalacao  # Estado de instalacao
+    │   └── criar_volume_controlador_instalacao  # Estado de instalação
     │
     └── run
         ├── build_docker_compose       # Gera docker-compose.yml via envsubst
-        └── docker compose up -d       # Sobe todos os servicos
+        └── docker compose up -d       # Sobe todos os serviços
             │
             ├── db                     # Banco de dados inicia
             ├── memcached              # Cache inicia
             ├── solr                   # Busca inicia
-            ├── app-atualizador        # Instala/atualiza SEI e modulos
-            ├── app                    # Aplicacao web inicia
+            ├── app-atualizador        # Instala/atualiza SEI e módulos
+            ├── app                    # Aplicação web inicia
             ├── app-agendador          # Jobs em background iniciam
-            └── balanceador            # Traefik comeca a rotear
+            └── balanceador            # Traefik começa a rotear
 ```
 
 ### Desenvolvimento (dev/)
@@ -173,20 +173,20 @@ make up
     │
     ├── prerequisites-up
     │   ├── env.env                    # Carrega config do banco escolhido
-    │   └── check-sei-path             # Valida codigo-fonte existe
+    │   └── check-sei-path             # Valida código-fonte existe
     │
     └── docker compose up -d
-        ├── database                   # Banco com schema pre-populado
+        ├── database                   # Banco com schema pré-populado
         ├── memcached                  # Cache
         ├── solr                       # Busca
-        ├── jod                        # Conversao de documentos
+        ├── jod                        # Conversão de documentos
         ├── smtp                       # MailCatcher
         └── httpd                      # App com XDebug (porta 8000)
 ```
 
 ---
 
-## Comunicacao entre Servicos
+## Comunicação entre Serviços
 
 | De | Para | Protocolo | Porta |
 |----|------|-----------|-------|
@@ -205,45 +205,45 @@ make up
 
 ## Volumes Persistentes
 
-| Volume | Conteudo | Backup Recomendado |
+| Volume | Conteúdo | Backup Recomendado |
 |--------|----------|-------------------|
 | `local-storage-db` | Dados do banco de dados | Sim |
-| `local-fontes-storage` | Codigo-fonte do SEI | Nao (vem do repositorio) |
+| `local-fontes-storage` | Código-fonte do SEI | Não (vem do repositório) |
 | `local-certs-storage` | Certificados SSL | Sim |
 | `local-arquivosexternos-storage` | Documentos anexados ao SEI | Sim |
-| `local-volume-solr` | Indices de busca Solr | Nao (reconstruivel) |
+| `local-volume-solr` | Índices de busca Solr | Não (reconstruível) |
 | `local-openldap-slapd-storage` | Config LDAP | Sim (se LDAP ativo) |
 | `local-openldap-db-storage` | Dados LDAP | Sim (se LDAP ativo) |
-| `local-controlador-instalacao-storage` | Estado de instalacao de modulos | Nao (reconstruivel) |
+| `local-controlador-instalacao-storage` | Estado de instalação de módulos | Não (reconstruível) |
 
 ---
 
-## Sistema de Modulos
+## Sistema de Módulos
 
-O SEI suporta modulos opcionais que sao instalados automaticamente pelo container `app-atualizador`. Cada modulo e controlado por variaveis `MODULO_*_INSTALAR` e `MODULO_*_VERSAO`.
+O SEI suporta módulos opcionais que são instalados automaticamente pelo container `app-atualizador`. Cada módulo é controlado por variáveis `MODULO_*_INSTALAR` e `MODULO_*_VERSAO`.
 
-| Modulo | Funcao |
+| Módulo | Função |
 |--------|--------|
-| **Estatisticas** | Painel de estatisticas de uso do SEI |
-| **REST / WSSEI** | API REST para integracao com sistemas externos |
-| **Gestao Documental** | Gestao do ciclo de vida de documentos |
-| **Resposta** | Modulo de respostas a demandas |
-| **Login Unico** | Integracao com GOV.BR (SSO) |
-| **Assinatura Avancada** | Assinatura digital com ICP-Brasil e cloud PSC |
-| **PEN / Barramento** | Tramitacao entre orgaos via Processo Eletronico Nacional |
-| **Peticionamento** | Peticionamento eletronico externo |
-| **Protocolo Integrado** | Integracao com Protocolo.GOV.BR |
-| **INCOM** | Integracao com Imprensa Nacional para publicacoes oficiais |
+| **Estatísticas** | Painel de estatísticas de uso do SEI |
+| **REST / WSSEI** | API REST para integração com sistemas externos |
+| **Gestão Documental** | Gestão do ciclo de vida de documentos |
+| **Resposta** | Módulo de respostas a demandas |
+| **Login Único** | Integração com GOV.BR (SSO) |
+| **Assinatura Avançada** | Assinatura digital com ICP-Brasil e cloud PSC |
+| **PEN / Barramento** | Tramitação entre órgãos via Processo Eletrônico Nacional |
+| **Peticionamento** | Peticionamento eletrônico externo |
+| **Protocolo Integrado** | Integração com Protocolo.GOV.BR |
+| **INCOM** | Integração com Imprensa Nacional para publicações oficiais |
 
 ---
 
-## Decisoes Arquiteturais
+## Decisões Arquiteturais
 
-| Decisao | Motivo |
+| Decisão | Motivo |
 |---------|--------|
-| Traefik em vez de HAProxy (v3.0.0+) | Integracao nativa com Docker labels, dashboard embutido |
-| Rocky Linux 9.3 em vez de CentOS 7 | CentOS 7 EOL, Rocky e continuidade do RHEL |
+| Traefik em vez de HAProxy (v3.0.0+) | Integração nativa com Docker labels, dashboard embutido |
+| Rocky Linux 9.3 em vez de CentOS 7 | CentOS 7 EOL, Rocky é continuidade do RHEL |
 | PHP 8.2 como stack principal | Compatibilidade com SEI 5.0+ |
-| Volumes externos no infra | Persistencia entre rebuilds, backup independente |
-| envsubst + sed para docker-compose | Geracao dinamica com toggles de servicos opcionais |
-| Imagens com schema pre-populado | Inicializacao rapida, sem necessidade de restaurar backups |
+| Volumes externos no infra | Persistência entre rebuilds, backup independente |
+| envsubst + sed para docker-compose | Geração dinâmica com toggles de serviços opcionais |
+| Imagens com schema pré-populado | Inicialização rápida, sem necessidade de restaurar backups |

--- a/docs/arquitetura.md
+++ b/docs/arquitetura.md
@@ -1,0 +1,249 @@
+# Arquitetura Tecnica - SEI-Docker
+
+## Visao Geral
+
+O SEI-Docker implementa uma arquitetura de microservicos baseada em containers Docker para o Sistema Eletronico de Informacoes (SEI). O projeto e destinado exclusivamente a ambientes de **Desenvolvimento, Teste e Homologacao (DTH)**, nao sendo recomendado para producao.
+
+---
+
+## Diagrama de Servicos
+
+```
+                         ┌─────────────────────────┐
+                         │     Usuario / Browser    │
+                         └────────────┬────────────┘
+                                      │
+                              ┌───────▼───────┐
+                              │    Traefik     │
+                              │  (balanceador) │
+                              │   :80 / :443   │
+                              └───────┬───────┘
+                                      │
+                    ┌─────────────────┼─────────────────┐
+                    │                 │                   │
+              ┌─────▼─────┐   ┌──────▼──────┐   ┌───────▼───────┐
+              │   App #1   │   │   App #2    │   │   App #N      │
+              │  (SEI/SIP) │   │  (SEI/SIP)  │   │  (SEI/SIP)    │
+              │  PHP 8.2   │   │  PHP 8.2    │   │  PHP 8.2      │
+              └─────┬──────┘   └──────┬──────┘   └───────┬───────┘
+                    │                 │                   │
+       ┌────────────┼─────────────────┼───────────────────┤
+       │            │                 │                   │
+ ┌─────▼─────┐ ┌───▼────┐ ┌────▼────┐ ┌────▼────┐ ┌─────▼──────┐
+ │   Banco   │ │Memcached│ │  Solr   │ │  JOD    │ │   Mail     │
+ │  de Dados │ │ :11211  │ │ :8983   │ │ (conv.) │ │  Catcher   │
+ └───────────┘ └────────┘ └─────────┘ └─────────┘ └────────────┘
+
+       ┌────────────┐  ┌───────────────┐
+       │  OpenLDAP   │  │  Agendador    │
+       │  :389/:636  │  │ (Cron/Gearman)│
+       └────────────┘  └───────────────┘
+```
+
+---
+
+## Camadas da Arquitetura
+
+### 1. Camada de Entrada (Load Balancer)
+
+| Componente | Imagem | Funcao |
+|------------|--------|--------|
+| **Traefik** | `traefik:v3.6.7` | Reverse proxy, balanceamento de carga, terminacao TLS, roteamento por labels |
+
+- Substituiu o HAProxy na versao 3.0.0
+- Suporta HTTP e HTTPS com certificados auto-gerados ou customizados
+- Dashboard administrativo disponivel em `/traefik`
+- Escalonamento horizontal transparente via Docker labels
+
+### 2. Camada de Aplicacao
+
+| Componente | Imagem Base | Funcao |
+|------------|-------------|--------|
+| **App (SEI/SIP)** | Rocky Linux 9.3 + PHP 8.2 | Aplicacao web principal |
+| **App Atualizador** | Mesma imagem do App | Executa atualizacoes de versao e instalacao de modulos |
+| **App Agendador** | Extensao do App | Jobs em background via Cron, Gearman e Supervisor |
+| **App Dev** | Extensao do App Base | Ambiente de desenvolvimento com XDebug |
+
+**Stack da aplicacao:**
+- Apache 2.4 + mod_ssl + PHP-FPM
+- PHP 8.2 com extensoes: bcmath, gd, gmp, imap, intl, ldap, mbstring, pdo, memcache, memcached, gearman
+- Java 1.8 (conversao de documentos)
+- Locale: pt_BR.ISO-8859-1
+
+### 3. Camada de Dados
+
+| Componente | Versao | Porta | Observacao |
+|------------|--------|-------|------------|
+| **MariaDB** | 10.5 | 3306 | Fork do MySQL, suporte completo |
+| **MySQL** | 8.0.21 | 3306 | Banco padrao para dev |
+| **PostgreSQL** | 15 | 5432 | Autenticacao SCRAM-SHA-256 |
+| **Oracle** | 11g XE | 1521 | Versao Express |
+| **SQL Server** | 2019 | 1433 | Experimental, nao para producao |
+
+Cada banco de dados possui imagens pre-populadas com o schema do SEI para as versoes 4.0, 4.1 e 5.0.
+
+### 4. Camada de Servicos Auxiliares
+
+| Componente | Imagem | Funcao |
+|------------|--------|--------|
+| **Memcached** | `memcached:latest` | Cache de sessoes PHP e cache da aplicacao |
+| **Apache Solr** | 8.2.0 / 9.4.0 / 9.6.1 | Indexacao e busca full-text de documentos |
+| **JOD Converter** | 4.4.8 (Alpine) | Conversao de documentos via LibreOffice |
+| **OpenLDAP** | osixia/openldap:1.2.2 | Autenticacao e diretorio de usuarios |
+| **MailCatcher** | schickling/mailcatcher | Captura de e-mails em ambiente de teste |
+
+### 5. Camada de Administracao (opcional)
+
+| Interface | URL | Funcao |
+|-----------|-----|--------|
+| **Traefik Dashboard** | `/traefik` | Monitoramento do load balancer |
+| **Adminer** | `/dbadmin` | Administracao do banco de dados |
+| **phpLDAPadmin** | `/phpldapadmin` | Administracao do LDAP |
+| **phpMemcachedAdmin** | `/memcachedadmin` | Administracao do cache |
+| **Solr Admin** | `/solr` | Administracao da busca |
+| **MailCatcher** | `/mailadmin` | Visualizacao de e-mails capturados |
+
+---
+
+## Hierarquia de Imagens Docker
+
+```
+centos:7                          rockylinux:9.3
+    └── base-centos7                  └── base-rocky93
+        ├── base-app (PHP 7)              ├── base-app-php8 (PHP 8)
+        │   ├── app-ci                    │   ├── app-ci-php8
+        │   │   └── app-ci-agendador      │   │   └── app-ci-php8-agendador
+        │   └── app-dev                   │   └── app-dev-php8
+        ├── solr8.2.0                     ├── solr9.4.0
+        └── jod                           └── solr9.6.1
+
+mysql:8.0.21          mariadb:10.5          postgres:15
+    └── base-mysql8       └── base-mariadb10.5  └── base-postgres15
+        ├── mysql8-sei41      ├── mariadb-sei40     ├── postgres-sei40
+        └── mysql8-sei50      ├── mariadb-sei41     ├── postgres-sei41
+                              └── mariadb-sei50     └── postgres-sei50
+
+oracleinanutshell/oracle-xe-11g       liaisonintl/mssql-server-linux:v2019
+    └── base-oracle11g                    └── base-sqlserver2019
+        ├── oracle-sei40                      ├── sqlserver-sei40
+        ├── oracle-sei41                      ├── sqlserver-sei41
+        └── oracle-sei50                      └── sqlserver-sei50
+
+traefik:v3.6.7                 osixia/openldap:1.2.2
+    └── traefik-base               └── openldap-base
+        └── traefik                    └── openldap
+```
+
+---
+
+## Fluxo de Inicializacao
+
+### Infraestrutura (infra/)
+
+```
+make setup
+    │
+    ├── check-version-compatibility    # Valida versao do fonte vs containers
+    ├── criar_volumes                  # Cria volumes Docker persistentes
+    │   ├── criar_volume_fontes        # Codigo-fonte do SEI
+    │   ├── criar_volume_certs         # Certificados SSL
+    │   ├── criar_volume_banco         # Dados do banco
+    │   ├── criar_volume_arquivos_externos  # Anexos
+    │   ├── criar_volume_solr          # Indices de busca
+    │   ├── criar_volume_openldap      # Dados LDAP
+    │   └── criar_volume_controlador_instalacao  # Estado de instalacao
+    │
+    └── run
+        ├── build_docker_compose       # Gera docker-compose.yml via envsubst
+        └── docker compose up -d       # Sobe todos os servicos
+            │
+            ├── db                     # Banco de dados inicia
+            ├── memcached              # Cache inicia
+            ├── solr                   # Busca inicia
+            ├── app-atualizador        # Instala/atualiza SEI e modulos
+            ├── app                    # Aplicacao web inicia
+            ├── app-agendador          # Jobs em background iniciam
+            └── balanceador            # Traefik comeca a rotear
+```
+
+### Desenvolvimento (dev/)
+
+```
+make up
+    │
+    ├── prerequisites-up
+    │   ├── env.env                    # Carrega config do banco escolhido
+    │   └── check-sei-path             # Valida codigo-fonte existe
+    │
+    └── docker compose up -d
+        ├── database                   # Banco com schema pre-populado
+        ├── memcached                  # Cache
+        ├── solr                       # Busca
+        ├── jod                        # Conversao de documentos
+        ├── smtp                       # MailCatcher
+        └── httpd                      # App com XDebug (porta 8000)
+```
+
+---
+
+## Comunicacao entre Servicos
+
+| De | Para | Protocolo | Porta |
+|----|------|-----------|-------|
+| Traefik | App | HTTP | 80/443 |
+| App | Banco de Dados | TCP | 3306/5432/1521/1433 |
+| App | Memcached | TCP | 11211 |
+| App | Solr | HTTP | 8983 |
+| App | JOD | HTTP | 8080 |
+| App | OpenLDAP | LDAP | 389/636 |
+| App | Mail | SMTP | 25 |
+| Agendador | Banco de Dados | TCP | 3306/5432/1521/1433 |
+| Agendador | Gearman | TCP | 4730 |
+| Agendador | Memcached | TCP | 11211 |
+
+---
+
+## Volumes Persistentes
+
+| Volume | Conteudo | Backup Recomendado |
+|--------|----------|-------------------|
+| `local-storage-db` | Dados do banco de dados | Sim |
+| `local-fontes-storage` | Codigo-fonte do SEI | Nao (vem do repositorio) |
+| `local-certs-storage` | Certificados SSL | Sim |
+| `local-arquivosexternos-storage` | Documentos anexados ao SEI | Sim |
+| `local-volume-solr` | Indices de busca Solr | Nao (reconstruivel) |
+| `local-openldap-slapd-storage` | Config LDAP | Sim (se LDAP ativo) |
+| `local-openldap-db-storage` | Dados LDAP | Sim (se LDAP ativo) |
+| `local-controlador-instalacao-storage` | Estado de instalacao de modulos | Nao (reconstruivel) |
+
+---
+
+## Sistema de Modulos
+
+O SEI suporta modulos opcionais que sao instalados automaticamente pelo container `app-atualizador`. Cada modulo e controlado por variaveis `MODULO_*_INSTALAR` e `MODULO_*_VERSAO`.
+
+| Modulo | Funcao |
+|--------|--------|
+| **Estatisticas** | Painel de estatisticas de uso do SEI |
+| **REST / WSSEI** | API REST para integracao com sistemas externos |
+| **Gestao Documental** | Gestao do ciclo de vida de documentos |
+| **Resposta** | Modulo de respostas a demandas |
+| **Login Unico** | Integracao com GOV.BR (SSO) |
+| **Assinatura Avancada** | Assinatura digital com ICP-Brasil e cloud PSC |
+| **PEN / Barramento** | Tramitacao entre orgaos via Processo Eletronico Nacional |
+| **Peticionamento** | Peticionamento eletronico externo |
+| **Protocolo Integrado** | Integracao com Protocolo.GOV.BR |
+| **INCOM** | Integracao com Imprensa Nacional para publicacoes oficiais |
+
+---
+
+## Decisoes Arquiteturais
+
+| Decisao | Motivo |
+|---------|--------|
+| Traefik em vez de HAProxy (v3.0.0+) | Integracao nativa com Docker labels, dashboard embutido |
+| Rocky Linux 9.3 em vez de CentOS 7 | CentOS 7 EOL, Rocky e continuidade do RHEL |
+| PHP 8.2 como stack principal | Compatibilidade com SEI 5.0+ |
+| Volumes externos no infra | Persistencia entre rebuilds, backup independente |
+| envsubst + sed para docker-compose | Geracao dinamica com toggles de servicos opcionais |
+| Imagens com schema pre-populado | Inicializacao rapida, sem necessidade de restaurar backups |

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -1,4 +1,4 @@
-# Containers - Referencia Tecnica
+# Containers - Referência Técnica
 
 Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
 
@@ -12,8 +12,8 @@ Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
 |----------|-------|
 | **Caminho** | `containers/base-centos/` |
 | **Base** | `centos:7` |
-| **Funcao** | Imagem base para containers PHP 7 (legado) |
-| **Observacao** | Repositorios redirecionados para vault.centos.org (CentOS 7 EOL) |
+| **Função** | Imagem base para containers PHP 7 (legado) |
+| **Observação** | Repositórios redirecionados para vault.centos.org (CentOS 7 EOL) |
 
 ### base-rocky93
 
@@ -21,11 +21,11 @@ Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
 |----------|-------|
 | **Caminho** | `containers/base-rocky93/` |
 | **Base** | `rockylinux:9.3` |
-| **Funcao** | Imagem base para containers PHP 8 e servicos modernos |
+| **Função** | Imagem base para containers PHP 8 e serviços modernos |
 
 ---
 
-## Containers de Aplicacao (PHP 8 - Atual)
+## Containers de Aplicação (PHP 8 - Atual)
 
 ### base-app-php8
 
@@ -33,7 +33,7 @@ Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
 |----------|-------|
 | **Caminho** | `containers/app-php8/app-base-php8/` |
 | **Base** | `processoeletronico/base-rocky93:latest` |
-| **Funcao** | Base com todas as dependencias PHP 8 |
+| **Função** | Base com todas as dependências PHP 8 |
 
 **Pacotes instalados:**
 - PHP 8.2: bcmath, gd, gmp, imap, intl, ldap, mbstring, odbc, pdo, memcache, memcached, gearman
@@ -42,7 +42,7 @@ Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
 - Drivers de banco: MySQL, SQL Server (ODBC), Oracle, PostgreSQL
 - wkhtmltopdf, ffmpeg
 - Locale: pt_BR.ISO-8859-1
-- XDebug 3 (disponivel para ativacao)
+- XDebug 3 (disponível para ativação)
 
 ### app-ci-php8
 
@@ -51,12 +51,12 @@ Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
 | **Caminho** | `containers/app-php8/app-ci-php8/` |
 | **Base** | `processoeletronico/base-app-php8:latest` |
 | **Portas** | 80, 443 |
-| **Funcao** | Container de CI/Producao com codigo SEI |
+| **Função** | Container de CI/Produção com código SEI |
 
 **Funcionalidades:**
-- Clona modulos do SEI via Git
+- Clona módulos do SEI via Git
 - Copia ConfiguracaoSEI.php e ConfiguracaoSip.php
-- Entrypoint configura banco, modulos e servicos na inicializacao
+- Entrypoint configura banco, módulos e serviços na inicialização
 - Suporta download de fontes via Git SSH ou GitHub Token
 
 ### app-ci-php8-agendador
@@ -66,11 +66,11 @@ Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
 | **Caminho** | `containers/app-php8/app-ci-php8-agendador/` |
 | **Base** | `processoeletronico/app-ci-php8:latest` |
 | **Entrypoint** | `/entrypoint-agendador.sh` |
-| **Funcao** | Jobs em background e tarefas agendadas |
+| **Função** | Jobs em background e tarefas agendadas |
 
-**Servicos gerenciados (Supervisor):**
-- Cron jobs: AgendamentoTarefaSEI.php, AgendamentoTarefaSip.php, limpeza de temporarios
-- Gearman job server (para modulo PEN)
+**Serviços gerenciados (Supervisor):**
+- Cron jobs: AgendamentoTarefaSEI.php, AgendamentoTarefaSip.php, limpeza de temporários
+- Gearman job server (para módulo PEN)
 - Workers do PEN configurados via `MODULO_PEN_QTD_WORKER_PROC`
 
 ### app-dev-php8
@@ -80,17 +80,17 @@ Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
 | **Caminho** | `containers/app-php8/app-dev-php8/` |
 | **Base** | `processoeletronico/base-app-php8:latest` |
 | **Porta** | 8000 |
-| **Funcao** | Ambiente de desenvolvimento com XDebug |
+| **Função** | Ambiente de desenvolvimento com XDebug |
 
 **Diferenciais:**
 - XDebug 3 ativado (porta 9003)
 - SSL enforcement desabilitado
 - Ferramentas de build instaladas
-- Codigo-fonte montado via volume externo
+- Código-fonte montado via volume externo
 
 ---
 
-## Containers de Aplicacao (PHP 7 - Legado)
+## Containers de Aplicação (PHP 7 - Legado)
 
 ### base-app
 
@@ -98,7 +98,7 @@ Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
 |----------|-------|
 | **Caminho** | `containers/app/app-base/` |
 | **Base** | `processoeletronico/base-centos7:latest` |
-| **Funcao** | Base PHP 7 (substituido por app-php8) |
+| **Função** | Base PHP 7 (substituído por app-php8) |
 
 ### app-ci
 
@@ -107,7 +107,7 @@ Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
 | **Caminho** | `containers/app/app-ci/` |
 | **Base** | `processoeletronico/base-app:latest` |
 | **Portas** | 80, 443 |
-| **Funcao** | CI/Producao PHP 7 |
+| **Função** | CI/Produção PHP 7 |
 
 ### app-ci-agendador
 
@@ -115,7 +115,7 @@ Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
 |----------|-------|
 | **Caminho** | `containers/app/app-ci-agendador/` |
 | **Base** | `processoeletronico/app-ci:latest` |
-| **Funcao** | Agendador PHP 7 |
+| **Função** | Agendador PHP 7 |
 
 ### app-dev
 
@@ -124,7 +124,7 @@ Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
 | **Caminho** | `containers/app/app-dev/` |
 | **Base** | `processoeletronico/base-app:latest` |
 | **Porta** | 8000 |
-| **Funcao** | Dev PHP 7 com XDebug |
+| **Função** | Dev PHP 7 com XDebug |
 
 ---
 
@@ -139,9 +139,9 @@ Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
 | `mariadb10.5-sei41` | `containers/databases/mariadb-sei41/` | `base-mariadb10.5` | SEI 4.1 |
 | `mariadb10.5-sei50` | `containers/databases/mariadb-sei50/` | `base-mariadb10.5` | SEI 5.0 |
 
-**Caracteristicas:**
-- Cria databases `sei` e `sip` com usuarios dedicados
-- Build em dois estagios: inicializacao do schema + copia dos dados
+**Características:**
+- Cria databases `sei` e `sip` com usuários dedicados
+- Build em dois estágios: inicialização do schema + cópia dos dados
 - Schema baixado do GitHub: `spbgovbr/sei-db-ref-executivo`
 
 ### MySQL 8
@@ -161,9 +161,9 @@ Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
 | `postgres15-sei41` | `containers/databases/postgres-sei41/` | `base-postgres15` | SEI 4.1 |
 | `postgres15-sei50` | `containers/databases/postgres-sei50/` | `base-postgres15` | SEI 5.0 |
 
-**Caracteristicas:**
-- Autenticacao SCRAM-SHA-256
-- Build em dois estagios similar ao MariaDB
+**Características:**
+- Autenticação SCRAM-SHA-256
+- Build em dois estágios similar ao MariaDB
 
 ### Oracle 11g
 
@@ -174,9 +174,9 @@ Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
 | `oracle11g-sei41` | `containers/databases/oracle-sei41/` | `base-oracle11g` | SEI 4.1 |
 | `oracle11g-sei50` | `containers/databases/oracle-sei50/` | `base-oracle11g` | SEI 5.0 |
 
-**Caracteristicas:**
-- Importacao via dump (.dmp) com utilitario `imp`
-- Character set com suporte a portugues brasileiro
+**Características:**
+- Importação via dump (.dmp) com utilitário `imp`
+- Character set com suporte a português brasileiro
 
 ### SQL Server 2019
 
@@ -187,10 +187,10 @@ Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
 | `sqlserver2019-sei41` | `containers/databases/sqlserver-sei41/` | `base-sqlserver2019` | SEI 4.1 |
 | `sqlserver2019-sei50` | `containers/databases/sqlserver-sei50/` | `base-sqlserver2019` | SEI 5.0 |
 
-**Caracteristicas:**
-- Experimental, nao recomendado para producao
-- Restauracao via backup (.bak) com `sqlcmd`
-- Senha SA padrao: `yourStrong(!)Password`
+**Características:**
+- Experimental, não recomendado para produção
+- Restauração via backup (.bak) com `sqlcmd`
+- Senha SA padrão: `yourStrong(!)Password`
 
 ---
 
@@ -205,21 +205,21 @@ Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
 **Cores criados automaticamente:**
 - `sei-protocolos` - Documentos de protocolo
 - `sei-bases-conhecimento` - Base de conhecimento
-- `sei-publicacoes` - Publicacoes
+- `sei-publicacoes` - Publicações
 
-**Observacao:** Solr 9.x executa como usuario `solr` (nao-root) com diretorio de dados em `/dados`.
+**Observação:** Solr 9.x executa como usuário `solr` (não-root) com diretório de dados em `/dados`.
 
 ---
 
-## Container de Conversao de Documentos (JOD)
+## Container de Conversão de Documentos (JOD)
 
-| Imagem | Caminho | Base | Funcao |
+| Imagem | Caminho | Base | Função |
 |--------|---------|------|--------|
 | `jod` | `containers/jod/` | `base-centos7` | JODConverter 2.2.2 (Tomcat) - legado |
 | `jod4.4.8` | `containers/jod4.4.8/` | `alpine:3.21` | JODConverter 4.4.8 (standalone) - atual |
 
 **JOD 4.4.8:**
-- LibreOffice com integracao nativa
+- LibreOffice com integração nativa
 - OpenJDK 17
 - Fontes: DejaVu, Noto, Terminus, Inconsolata, FontAwesome
 - Heap Java: 2GB
@@ -234,8 +234,8 @@ Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
 | `memcached` | `containers/memcached/` | `memcached:latest` | 11211 |
 
 **Usos:**
-- Cache de sessoes PHP (quando `APP_MEMCACHED_SESSION=true`)
-- Cache da aplicacao SEI
+- Cache de sessões PHP (quando `APP_MEMCACHED_SESSION=true`)
+- Cache da aplicação SEI
 
 ---
 
@@ -248,7 +248,7 @@ Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
 | `haproxy-base` | `containers/haproxy/haproxy-base/` | (legado) | -- |
 | `haproxy` | `containers/haproxy/haproxy/` | `haproxy-base` | 80, 443 |
 
-**Traefik** e o load balancer atual (desde v3.0.0). Possui configuracao dinamica em `/etc/traefik/dynamic_conf/conf.yml`.
+**Traefik** é o load balancer atual (desde v3.0.0). Possui configuração dinâmica em `/etc/traefik/dynamic_conf/conf.yml`.
 
 ---
 
@@ -260,15 +260,15 @@ Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
 | `openldap` | `containers/openldap/openldap/` | `openldap-base` | 389, 636 |
 | `phpldapadmin` | `containers/phpldapadmin/` | `osixia/phpldapadmin:0.9.0` | 80 |
 
-**OpenLDAP:** Inclui LDIF de bootstrap com usuario de teste (senha: `123456`).
+**OpenLDAP:** Inclui LDIF de bootstrap com usuário de teste (senha: `123456`).
 
 ---
 
-## Containers de Administracao
+## Containers de Administração
 
-| Imagem | Caminho | Base | Funcao |
+| Imagem | Caminho | Base | Função |
 |--------|---------|------|--------|
-| `phpmemcachedadmin-base` | `containers/phpmemcachedadmin/phpmemcachedadmin-base/` | (pre-built) | Base admin Memcached |
+| `phpmemcachedadmin-base` | `containers/phpmemcachedadmin/phpmemcachedadmin-base/` | (pré-built) | Base admin Memcached |
 | `phpmemcachedadmin` | `containers/phpmemcachedadmin/phpmemcachedadmin/` | `phpmemcachedadmin-base` | Admin Memcached |
 | `dbadminer` | `containers/dbadminer/` | `dockette/adminer:full` | Admin universal de banco |
 | `mailcatcher` | `containers/mailcatcher/` | `schickling/mailcatcher` | Captura SMTP (porta web 1080) |
@@ -280,15 +280,15 @@ Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
 ```bash
 cd containers
 
-# Copiar template de configuracao
+# Copiar template de configuração
 make getenv
 
-# Editar envcontainers.env com suas configuracoes
+# Editar envcontainers.env com suas configurações
 
 # Build de todas as imagens
 make build-conteiners
 
-# Build de uma imagem especifica
+# Build de uma imagem específica
 make build-conteiner-base-rocky93
 make build-conteiner-base-app-php8
 make build-conteiner-app-ci-php8

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -1,0 +1,305 @@
+# Containers - Referencia Tecnica
+
+Detalhamento de todas as 44 imagens Docker do projeto SEI-Docker.
+
+---
+
+## Imagens Base
+
+### base-centos7
+
+| Atributo | Valor |
+|----------|-------|
+| **Caminho** | `containers/base-centos/` |
+| **Base** | `centos:7` |
+| **Funcao** | Imagem base para containers PHP 7 (legado) |
+| **Observacao** | Repositorios redirecionados para vault.centos.org (CentOS 7 EOL) |
+
+### base-rocky93
+
+| Atributo | Valor |
+|----------|-------|
+| **Caminho** | `containers/base-rocky93/` |
+| **Base** | `rockylinux:9.3` |
+| **Funcao** | Imagem base para containers PHP 8 e servicos modernos |
+
+---
+
+## Containers de Aplicacao (PHP 8 - Atual)
+
+### base-app-php8
+
+| Atributo | Valor |
+|----------|-------|
+| **Caminho** | `containers/app-php8/app-base-php8/` |
+| **Base** | `processoeletronico/base-rocky93:latest` |
+| **Funcao** | Base com todas as dependencias PHP 8 |
+
+**Pacotes instalados:**
+- PHP 8.2: bcmath, gd, gmp, imap, intl, ldap, mbstring, odbc, pdo, memcache, memcached, gearman
+- Apache 2.4 com mod_ssl
+- Java 1.8 (OpenJDK)
+- Drivers de banco: MySQL, SQL Server (ODBC), Oracle, PostgreSQL
+- wkhtmltopdf, ffmpeg
+- Locale: pt_BR.ISO-8859-1
+- XDebug 3 (disponivel para ativacao)
+
+### app-ci-php8
+
+| Atributo | Valor |
+|----------|-------|
+| **Caminho** | `containers/app-php8/app-ci-php8/` |
+| **Base** | `processoeletronico/base-app-php8:latest` |
+| **Portas** | 80, 443 |
+| **Funcao** | Container de CI/Producao com codigo SEI |
+
+**Funcionalidades:**
+- Clona modulos do SEI via Git
+- Copia ConfiguracaoSEI.php e ConfiguracaoSip.php
+- Entrypoint configura banco, modulos e servicos na inicializacao
+- Suporta download de fontes via Git SSH ou GitHub Token
+
+### app-ci-php8-agendador
+
+| Atributo | Valor |
+|----------|-------|
+| **Caminho** | `containers/app-php8/app-ci-php8-agendador/` |
+| **Base** | `processoeletronico/app-ci-php8:latest` |
+| **Entrypoint** | `/entrypoint-agendador.sh` |
+| **Funcao** | Jobs em background e tarefas agendadas |
+
+**Servicos gerenciados (Supervisor):**
+- Cron jobs: AgendamentoTarefaSEI.php, AgendamentoTarefaSip.php, limpeza de temporarios
+- Gearman job server (para modulo PEN)
+- Workers do PEN configurados via `MODULO_PEN_QTD_WORKER_PROC`
+
+### app-dev-php8
+
+| Atributo | Valor |
+|----------|-------|
+| **Caminho** | `containers/app-php8/app-dev-php8/` |
+| **Base** | `processoeletronico/base-app-php8:latest` |
+| **Porta** | 8000 |
+| **Funcao** | Ambiente de desenvolvimento com XDebug |
+
+**Diferenciais:**
+- XDebug 3 ativado (porta 9003)
+- SSL enforcement desabilitado
+- Ferramentas de build instaladas
+- Codigo-fonte montado via volume externo
+
+---
+
+## Containers de Aplicacao (PHP 7 - Legado)
+
+### base-app
+
+| Atributo | Valor |
+|----------|-------|
+| **Caminho** | `containers/app/app-base/` |
+| **Base** | `processoeletronico/base-centos7:latest` |
+| **Funcao** | Base PHP 7 (substituido por app-php8) |
+
+### app-ci
+
+| Atributo | Valor |
+|----------|-------|
+| **Caminho** | `containers/app/app-ci/` |
+| **Base** | `processoeletronico/base-app:latest` |
+| **Portas** | 80, 443 |
+| **Funcao** | CI/Producao PHP 7 |
+
+### app-ci-agendador
+
+| Atributo | Valor |
+|----------|-------|
+| **Caminho** | `containers/app/app-ci-agendador/` |
+| **Base** | `processoeletronico/app-ci:latest` |
+| **Funcao** | Agendador PHP 7 |
+
+### app-dev
+
+| Atributo | Valor |
+|----------|-------|
+| **Caminho** | `containers/app/app-dev/` |
+| **Base** | `processoeletronico/base-app:latest` |
+| **Porta** | 8000 |
+| **Funcao** | Dev PHP 7 com XDebug |
+
+---
+
+## Containers de Banco de Dados
+
+### MariaDB
+
+| Imagem | Caminho | Base | Schema |
+|--------|---------|------|--------|
+| `base-mariadb10.5` | `containers/databases/mariadb-base/` | `mariadb:10.5` | -- |
+| `mariadb10.5-sei40` | `containers/databases/mariadb-sei40/` | `base-mariadb10.5` | SEI 4.0 |
+| `mariadb10.5-sei41` | `containers/databases/mariadb-sei41/` | `base-mariadb10.5` | SEI 4.1 |
+| `mariadb10.5-sei50` | `containers/databases/mariadb-sei50/` | `base-mariadb10.5` | SEI 5.0 |
+
+**Caracteristicas:**
+- Cria databases `sei` e `sip` com usuarios dedicados
+- Build em dois estagios: inicializacao do schema + copia dos dados
+- Schema baixado do GitHub: `spbgovbr/sei-db-ref-executivo`
+
+### MySQL 8
+
+| Imagem | Caminho | Base | Schema |
+|--------|---------|------|--------|
+| `base-mysql8` | `containers/databases/mysql8-base/` | `mysql:8.0.21` | -- |
+| `mysql8-sei41` | `containers/databases/mysql8-sei41/` | `base-mysql8` | SEI 4.1 |
+| `mysql8-sei50` | `containers/databases/mysql8-sei50/` | `base-mysql8` | SEI 5.0 |
+
+### PostgreSQL 15
+
+| Imagem | Caminho | Base | Schema |
+|--------|---------|------|--------|
+| `base-postgres15` | `containers/databases/postgres-base/` | `postgres:15` | -- |
+| `postgres15-sei40` | `containers/databases/postgres-sei40/` | `base-postgres15` | SEI 4.0 |
+| `postgres15-sei41` | `containers/databases/postgres-sei41/` | `base-postgres15` | SEI 4.1 |
+| `postgres15-sei50` | `containers/databases/postgres-sei50/` | `base-postgres15` | SEI 5.0 |
+
+**Caracteristicas:**
+- Autenticacao SCRAM-SHA-256
+- Build em dois estagios similar ao MariaDB
+
+### Oracle 11g
+
+| Imagem | Caminho | Base | Schema |
+|--------|---------|------|--------|
+| `base-oracle11g` | `containers/databases/oracle-base/` | `oracleinanutshell/oracle-xe-11g` | -- |
+| `oracle11g-sei40` | `containers/databases/oracle-sei40/` | `base-oracle11g` | SEI 4.0 |
+| `oracle11g-sei41` | `containers/databases/oracle-sei41/` | `base-oracle11g` | SEI 4.1 |
+| `oracle11g-sei50` | `containers/databases/oracle-sei50/` | `base-oracle11g` | SEI 5.0 |
+
+**Caracteristicas:**
+- Importacao via dump (.dmp) com utilitario `imp`
+- Character set com suporte a portugues brasileiro
+
+### SQL Server 2019
+
+| Imagem | Caminho | Base | Schema |
+|--------|---------|------|--------|
+| `base-sqlserver2019` | `containers/databases/sqlserver-base/` | `liaisonintl/mssql-server-linux:v2019` | -- |
+| `sqlserver2019-sei40` | `containers/databases/sqlserver-sei40/` | `base-sqlserver2019` | SEI 4.0 |
+| `sqlserver2019-sei41` | `containers/databases/sqlserver-sei41/` | `base-sqlserver2019` | SEI 4.1 |
+| `sqlserver2019-sei50` | `containers/databases/sqlserver-sei50/` | `base-sqlserver2019` | SEI 5.0 |
+
+**Caracteristicas:**
+- Experimental, nao recomendado para producao
+- Restauracao via backup (.bak) com `sqlcmd`
+- Senha SA padrao: `yourStrong(!)Password`
+
+---
+
+## Containers de Busca (Solr)
+
+| Imagem | Caminho | Base | Java | Porta |
+|--------|---------|------|------|-------|
+| `solr8.2.0` | `containers/solr/` | `base-centos7` | Java 8 | 8983 |
+| `solr9.4.0` | `containers/solr-9.4.0/` | `base-rocky93` | Java 17 | 8983 |
+| `solr9.6.1` | `containers/solr-9.6.1/` | `base-rocky93` | Java 17 | 8983 |
+
+**Cores criados automaticamente:**
+- `sei-protocolos` - Documentos de protocolo
+- `sei-bases-conhecimento` - Base de conhecimento
+- `sei-publicacoes` - Publicacoes
+
+**Observacao:** Solr 9.x executa como usuario `solr` (nao-root) com diretorio de dados em `/dados`.
+
+---
+
+## Container de Conversao de Documentos (JOD)
+
+| Imagem | Caminho | Base | Funcao |
+|--------|---------|------|--------|
+| `jod` | `containers/jod/` | `base-centos7` | JODConverter 2.2.2 (Tomcat) - legado |
+| `jod4.4.8` | `containers/jod4.4.8/` | `alpine:3.21` | JODConverter 4.4.8 (standalone) - atual |
+
+**JOD 4.4.8:**
+- LibreOffice com integracao nativa
+- OpenJDK 17
+- Fontes: DejaVu, Noto, Terminus, Inconsolata, FontAwesome
+- Heap Java: 2GB
+- Executa como JAR standalone
+
+---
+
+## Container de Cache (Memcached)
+
+| Imagem | Caminho | Base | Porta |
+|--------|---------|------|-------|
+| `memcached` | `containers/memcached/` | `memcached:latest` | 11211 |
+
+**Usos:**
+- Cache de sessoes PHP (quando `APP_MEMCACHED_SESSION=true`)
+- Cache da aplicacao SEI
+
+---
+
+## Containers de Load Balancer
+
+| Imagem | Caminho | Base | Portas |
+|--------|---------|------|--------|
+| `traefik-base` | `containers/traefik/traefik-base/` | `traefik:v3.6.7` | -- |
+| `traefik` | `containers/traefik/traefik/` | `traefik-base` | 80, 443 |
+| `haproxy-base` | `containers/haproxy/haproxy-base/` | (legado) | -- |
+| `haproxy` | `containers/haproxy/haproxy/` | `haproxy-base` | 80, 443 |
+
+**Traefik** e o load balancer atual (desde v3.0.0). Possui configuracao dinamica em `/etc/traefik/dynamic_conf/conf.yml`.
+
+---
+
+## Containers LDAP
+
+| Imagem | Caminho | Base | Porta |
+|--------|---------|------|-------|
+| `openldap-base` | `containers/openldap/openldap-base/` | `osixia/openldap:1.2.2` | 389, 636 |
+| `openldap` | `containers/openldap/openldap/` | `openldap-base` | 389, 636 |
+| `phpldapadmin` | `containers/phpldapadmin/` | `osixia/phpldapadmin:0.9.0` | 80 |
+
+**OpenLDAP:** Inclui LDIF de bootstrap com usuario de teste (senha: `123456`).
+
+---
+
+## Containers de Administracao
+
+| Imagem | Caminho | Base | Funcao |
+|--------|---------|------|--------|
+| `phpmemcachedadmin-base` | `containers/phpmemcachedadmin/phpmemcachedadmin-base/` | (pre-built) | Base admin Memcached |
+| `phpmemcachedadmin` | `containers/phpmemcachedadmin/phpmemcachedadmin/` | `phpmemcachedadmin-base` | Admin Memcached |
+| `dbadminer` | `containers/dbadminer/` | `dockette/adminer:full` | Admin universal de banco |
+| `mailcatcher` | `containers/mailcatcher/` | `schickling/mailcatcher` | Captura SMTP (porta web 1080) |
+
+---
+
+## Comandos de Build
+
+```bash
+cd containers
+
+# Copiar template de configuracao
+make getenv
+
+# Editar envcontainers.env com suas configuracoes
+
+# Build de todas as imagens
+make build-conteiners
+
+# Build de uma imagem especifica
+make build-conteiner-base-rocky93
+make build-conteiner-base-app-php8
+make build-conteiner-app-ci-php8
+make build-conteiner-mysql8-sei50
+
+# Apagar uma imagem
+make erase-conteiner-app-ci-php8
+
+# Publicar no registry
+make publish-container-app-ci-php8
+
+# Apagar todas as imagens locais
+make erase-conteiners-local
+```

--- a/docs/desenvolvimento.md
+++ b/docs/desenvolvimento.md
@@ -1,0 +1,306 @@
+# Ambiente de Desenvolvimento
+
+Guia tecnico para configuracao e uso do ambiente de desenvolvimento local do SEI-Docker.
+
+---
+
+## Visao Geral
+
+O ambiente de desenvolvimento (`dev/`) oferece uma configuracao simplificada com:
+
+- XDebug habilitado para debug remoto
+- Codigo-fonte montado via volume (edicao ao vivo)
+- Portas mapeadas diretamente para o host
+- Troca facil entre bancos de dados e versoes do SEI
+- MailCatcher para captura de e-mails
+
+---
+
+## Estrutura
+
+```
+dev/
+├── Makefile                    # Automacao (up, down, config, update)
+├── docker-compose.yml          # Orquestracao simplificada
+├── envs/                       # Templates de ambiente
+│   ├── env-mysql-sei4.env
+│   ├── env-mysql-sei5.env
+│   ├── env-oracle-sei4.env
+│   ├── env-oracle-sei5.env
+│   ├── env-postgres-sei4.env
+│   ├── env-postgres-sei5.env
+│   ├── env-sqlserver-sei4.env
+│   └── env-sqlserver-sei5.env
+└── tests/                      # Testes funcionais
+    ├── Makefile
+    └── Selenium/
+```
+
+---
+
+## Quick Start
+
+### 1. Pre-requisitos
+
+- Docker Engine 20+
+- Docker Compose v2+
+- Codigo-fonte do SEI (obtido separadamente)
+- GNU Make
+
+### 2. Definir caminho dos fontes
+
+```bash
+export SEI_PATH=~/sei/FonteSEI
+```
+
+O diretorio deve conter as pastas `sei/` e `sip/` com o codigo-fonte.
+
+### 3. Escolher banco de dados e versao
+
+```bash
+cd dev
+
+# Opcoes disponiveis:
+# mysql-sei4, mysql-sei5, oracle-sei4, oracle-sei5
+# postgres-sei4, postgres-sei5, sqlserver-sei4, sqlserver-sei5
+
+make config base=mysql-sei5
+```
+
+Isso copia o template `envs/env-mysql-sei5.env` para `env.env`.
+
+### 4. Subir o ambiente
+
+```bash
+make up
+```
+
+### 5. Acessar o SEI
+
+| Servico | URL | Credenciais |
+|---------|-----|-------------|
+| **SEI** | http://localhost:8000/sei | `teste` / `teste` |
+| **SIP** | http://localhost:8000/sip | `teste` / `teste` |
+| **MailCatcher** | http://localhost:1080 | -- |
+
+---
+
+## Comandos do Makefile
+
+| Comando | Descricao |
+|---------|-----------|
+| `make help` | Mostra ajuda |
+| `make up` | Sobe o ambiente (verifica pre-requisitos) |
+| `make up-update` | Sobe e executa scripts de atualizacao do SEI/SIP |
+| `make update` | Executa apenas os scripts de atualizacao |
+| `make config base=X` | Troca o banco/versao (ver opcoes acima) |
+| `make down` | Para o ambiente (preserva volumes) |
+| `make restart` | Para e sobe novamente |
+| `make destroy` | Para e apaga todos os volumes (DESTRUTIVO) |
+| `make check-sei-path` | Verifica se o codigo-fonte existe |
+| `make check-sei-isalive` | Verifica se o SEI responde com tela de login |
+| `make check-sei-ispinging` | Verifica se o Apache esta respondendo |
+
+---
+
+## Servicos do Docker Compose
+
+| Servico | Container | Imagem | Porta no Host |
+|---------|-----------|--------|---------------|
+| `httpd` | `httpd` | `app-dev-php8` | 8000 |
+| `database` | `${DATABASE_HOST}` | Variavel | Porta do banco |
+| `memcached` | `memcached` | `memcached` | 11211 |
+| `solr` | `solr` | `solr9.6.1` | 8983 |
+| `jod` | `jod` | `jod4.4.8` | -- |
+| `smtp` | `smtp` | `mailcatcher` | 1080 |
+
+### Portas por Banco de Dados
+
+| Banco | Porta |
+|-------|-------|
+| MySQL | 3306 |
+| PostgreSQL | 5432 |
+| Oracle | 1521 |
+| SQL Server | 1433 |
+
+---
+
+## Configuracao do XDebug
+
+O container `httpd` (app-dev-php8) vem com XDebug 3 pre-configurado.
+
+### Variaveis de Ambiente
+
+| Variavel | Valor Padrao | Descricao |
+|----------|-------------|-----------|
+| `XDEBUG_MODE` | `debug` | Modo: `debug`, `profile`, `trace`, `off` |
+| `XDEBUG_SESSION` | `default` | Nome da sessao / IDE key |
+| `XDEBUG_CONFIG` | `idekey=default client_host=${HOST_IP} client_port=9003 discover_client_host=1` | Config completa |
+
+### Configurar IP do Host
+
+Para que o XDebug se conecte a sua IDE, defina o IP do host:
+
+```bash
+# Linux
+export HOST_IP=$(hostname -I | awk '{print $1}')
+
+# WSL2
+export HOST_IP=$(cat /etc/resolv.conf | grep nameserver | awk '{print $2}')
+
+# macOS
+export HOST_IP=$(ifconfig en0 | grep 'inet ' | awk '{print $2}')
+```
+
+### Configuracao na IDE
+
+**VS Code (launch.json):**
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Listen for XDebug",
+      "type": "php",
+      "request": "launch",
+      "port": 9003,
+      "pathMappings": {
+        "/opt/sei": "${workspaceFolder}/sei",
+        "/opt/sip": "${workspaceFolder}/sip",
+        "/opt/infra": "${workspaceFolder}/infra"
+      }
+    }
+  ]
+}
+```
+
+**PHPStorm:**
+1. Settings > PHP > Debug > Xdebug: Porta 9003
+2. Settings > PHP > Servers: Host `localhost`, Porta `8000`
+3. Path mappings: `/opt/sei` -> diretorio local `sei/`
+
+---
+
+## Montagem do Codigo-Fonte
+
+O codigo-fonte e montado como volume em `/opt/` dentro do container `httpd`:
+
+```yaml
+volumes:
+  - ${SEI_PATH}:/opt/
+```
+
+**Estrutura esperada do `SEI_PATH`:**
+```
+${SEI_PATH}/
+├── sei/
+│   ├── web/
+│   ├── scripts/
+│   └── ...
+├── sip/
+│   ├── web/
+│   └── ...
+└── infra/
+    └── ...
+```
+
+Alteracoes nos arquivos sao refletidas imediatamente no container (sem rebuild).
+
+---
+
+## Troca de Banco de Dados
+
+Para trocar o banco de dados ou a versao do SEI:
+
+```bash
+# Parar o ambiente atual
+make down
+
+# (Opcional) Apagar dados do banco anterior
+make destroy
+
+# Trocar configuracao
+make config base=postgres-sei5
+
+# Subir com novo banco
+make up
+```
+
+### Combinacoes Disponiveis
+
+| Base | Banco | Versao SEI | Imagem |
+|------|-------|------------|--------|
+| `mysql-sei4` | MariaDB 10.5 | 4.0 | `mariadb10.5-sei40` |
+| `mysql-sei5` | MySQL 8 | 5.0 | `mysql8-sei50` |
+| `oracle-sei4` | Oracle 11g | 4.0 | `oracle11g-sei40` |
+| `oracle-sei5` | Oracle 11g | 5.0 | `oracle11g-sei50` |
+| `postgres-sei4` | PostgreSQL 15 | 4.0 | `postgres15-sei40` |
+| `postgres-sei5` | PostgreSQL 15 | 5.0 | `postgres15-sei50` |
+| `sqlserver-sei4` | SQL Server 2019 | 4.0 | `sqlserver2019-sei40` |
+| `sqlserver-sei5` | SQL Server 2019 | 5.0 | `sqlserver2019-sei50` |
+
+---
+
+## Atualizacao de Versao
+
+Quando atualizar o codigo-fonte do SEI para uma nova versao, execute os scripts de atualizacao:
+
+```bash
+make update
+```
+
+Ou suba o ambiente ja executando o update:
+
+```bash
+make up-update
+```
+
+Isso executa internamente:
+1. `atualizar_versao_sip.php` - Atualiza schema do SIP
+2. `atualizar_versao_sei.php` - Atualiza schema do SEI
+3. `atualizar_recursos_sei.php` - Atualiza recursos do SEI
+
+---
+
+## Resolucao de Problemas
+
+### SEI nao inicia
+
+```bash
+# Verificar se o caminho dos fontes esta correto
+make check-sei-path
+
+# Verificar se o Apache esta respondendo
+make check-sei-ispinging
+
+# Verificar se o SEI responde com login
+make check-sei-isalive
+
+# Ver logs do container
+docker logs httpd
+```
+
+### Erro de conexao com banco
+
+```bash
+# Verificar se o container do banco esta rodando
+docker ps | grep -E "mysql|postgres|oracle|sqlserver"
+
+# Ver logs do banco
+docker logs $(docker ps -qf "name=mysql\|postgres\|oracle\|sqlserver")
+```
+
+### XDebug nao conecta
+
+1. Verificar se `HOST_IP` esta definido corretamente
+2. Verificar se a porta 9003 esta aberta no firewall do host
+3. Testar com: `XDEBUG_MODE=debug,develop` para mensagens de erro detalhadas
+4. No WSL2, verificar regra de firewall do Windows
+
+### Volumes com dados antigos
+
+```bash
+# Destruir tudo e recriar
+make destroy
+make up
+```

--- a/docs/desenvolvimento.md
+++ b/docs/desenvolvimento.md
@@ -1,17 +1,17 @@
 # Ambiente de Desenvolvimento
 
-Guia tecnico para configuracao e uso do ambiente de desenvolvimento local do SEI-Docker.
+Guia técnico para configuração e uso do ambiente de desenvolvimento local do SEI-Docker.
 
 ---
 
-## Visao Geral
+## Visão Geral
 
-O ambiente de desenvolvimento (`dev/`) oferece uma configuracao simplificada com:
+O ambiente de desenvolvimento (`dev/`) oferece uma configuração simplificada com:
 
 - XDebug habilitado para debug remoto
-- Codigo-fonte montado via volume (edicao ao vivo)
+- Código-fonte montado via volume (edição ao vivo)
 - Portas mapeadas diretamente para o host
-- Troca facil entre bancos de dados e versoes do SEI
+- Troca fácil entre bancos de dados e versões do SEI
 - MailCatcher para captura de e-mails
 
 ---
@@ -20,8 +20,8 @@ O ambiente de desenvolvimento (`dev/`) oferece uma configuracao simplificada com
 
 ```
 dev/
-├── Makefile                    # Automacao (up, down, config, update)
-├── docker-compose.yml          # Orquestracao simplificada
+├── Makefile                    # Automação (up, down, config, update)
+├── docker-compose.yml          # Orquestração simplificada
 ├── envs/                       # Templates de ambiente
 │   ├── env-mysql-sei4.env
 │   ├── env-mysql-sei5.env
@@ -40,11 +40,11 @@ dev/
 
 ## Quick Start
 
-### 1. Pre-requisitos
+### 1. Pré-requisitos
 
 - Docker Engine 20+
 - Docker Compose v2+
-- Codigo-fonte do SEI (obtido separadamente)
+- Código-fonte do SEI (obtido separadamente)
 - GNU Make
 
 ### 2. Definir caminho dos fontes
@@ -53,14 +53,14 @@ dev/
 export SEI_PATH=~/sei/FonteSEI
 ```
 
-O diretorio deve conter as pastas `sei/` e `sip/` com o codigo-fonte.
+O diretório deve conter as pastas `sei/` e `sip/` com o código-fonte.
 
-### 3. Escolher banco de dados e versao
+### 3. Escolher banco de dados e versão
 
 ```bash
 cd dev
 
-# Opcoes disponiveis:
+# Opções disponíveis:
 # mysql-sei4, mysql-sei5, oracle-sei4, oracle-sei5
 # postgres-sei4, postgres-sei5, sqlserver-sei4, sqlserver-sei5
 
@@ -77,7 +77,7 @@ make up
 
 ### 5. Acessar o SEI
 
-| Servico | URL | Credenciais |
+| Serviço | URL | Credenciais |
 |---------|-----|-------------|
 | **SEI** | http://localhost:8000/sei | `teste` / `teste` |
 | **SIP** | http://localhost:8000/sip | `teste` / `teste` |
@@ -87,28 +87,28 @@ make up
 
 ## Comandos do Makefile
 
-| Comando | Descricao |
+| Comando | Descrição |
 |---------|-----------|
 | `make help` | Mostra ajuda |
-| `make up` | Sobe o ambiente (verifica pre-requisitos) |
-| `make up-update` | Sobe e executa scripts de atualizacao do SEI/SIP |
-| `make update` | Executa apenas os scripts de atualizacao |
-| `make config base=X` | Troca o banco/versao (ver opcoes acima) |
+| `make up` | Sobe o ambiente (verifica pré-requisitos) |
+| `make up-update` | Sobe e executa scripts de atualização do SEI/SIP |
+| `make update` | Executa apenas os scripts de atualização |
+| `make config base=X` | Troca o banco/versão (ver opções acima) |
 | `make down` | Para o ambiente (preserva volumes) |
 | `make restart` | Para e sobe novamente |
 | `make destroy` | Para e apaga todos os volumes (DESTRUTIVO) |
-| `make check-sei-path` | Verifica se o codigo-fonte existe |
+| `make check-sei-path` | Verifica se o código-fonte existe |
 | `make check-sei-isalive` | Verifica se o SEI responde com tela de login |
-| `make check-sei-ispinging` | Verifica se o Apache esta respondendo |
+| `make check-sei-ispinging` | Verifica se o Apache está respondendo |
 
 ---
 
-## Servicos do Docker Compose
+## Serviços do Docker Compose
 
-| Servico | Container | Imagem | Porta no Host |
+| Serviço | Container | Imagem | Porta no Host |
 |---------|-----------|--------|---------------|
 | `httpd` | `httpd` | `app-dev-php8` | 8000 |
-| `database` | `${DATABASE_HOST}` | Variavel | Porta do banco |
+| `database` | `${DATABASE_HOST}` | Variável | Porta do banco |
 | `memcached` | `memcached` | `memcached` | 11211 |
 | `solr` | `solr` | `solr9.6.1` | 8983 |
 | `jod` | `jod` | `jod4.4.8` | -- |
@@ -125,21 +125,21 @@ make up
 
 ---
 
-## Configuracao do XDebug
+## Configuração do XDebug
 
-O container `httpd` (app-dev-php8) vem com XDebug 3 pre-configurado.
+O container `httpd` (app-dev-php8) vem com XDebug 3 pré-configurado.
 
-### Variaveis de Ambiente
+### Variáveis de Ambiente
 
-| Variavel | Valor Padrao | Descricao |
+| Variável | Valor Padrão | Descrição |
 |----------|-------------|-----------|
 | `XDEBUG_MODE` | `debug` | Modo: `debug`, `profile`, `trace`, `off` |
-| `XDEBUG_SESSION` | `default` | Nome da sessao / IDE key |
+| `XDEBUG_SESSION` | `default` | Nome da sessão / IDE key |
 | `XDEBUG_CONFIG` | `idekey=default client_host=${HOST_IP} client_port=9003 discover_client_host=1` | Config completa |
 
 ### Configurar IP do Host
 
-Para que o XDebug se conecte a sua IDE, defina o IP do host:
+Para que o XDebug se conecte à sua IDE, defina o IP do host:
 
 ```bash
 # Linux
@@ -152,7 +152,7 @@ export HOST_IP=$(cat /etc/resolv.conf | grep nameserver | awk '{print $2}')
 export HOST_IP=$(ifconfig en0 | grep 'inet ' | awk '{print $2}')
 ```
 
-### Configuracao na IDE
+### Configuração na IDE
 
 **VS Code (launch.json):**
 ```json
@@ -177,13 +177,13 @@ export HOST_IP=$(ifconfig en0 | grep 'inet ' | awk '{print $2}')
 **PHPStorm:**
 1. Settings > PHP > Debug > Xdebug: Porta 9003
 2. Settings > PHP > Servers: Host `localhost`, Porta `8000`
-3. Path mappings: `/opt/sei` -> diretorio local `sei/`
+3. Path mappings: `/opt/sei` -> diretório local `sei/`
 
 ---
 
-## Montagem do Codigo-Fonte
+## Montagem do Código-Fonte
 
-O codigo-fonte e montado como volume em `/opt/` dentro do container `httpd`:
+O código-fonte é montado como volume em `/opt/` dentro do container `httpd`:
 
 ```yaml
 volumes:
@@ -204,13 +204,13 @@ ${SEI_PATH}/
     └── ...
 ```
 
-Alteracoes nos arquivos sao refletidas imediatamente no container (sem rebuild).
+Alterações nos arquivos são refletidas imediatamente no container (sem rebuild).
 
 ---
 
 ## Troca de Banco de Dados
 
-Para trocar o banco de dados ou a versao do SEI:
+Para trocar o banco de dados ou a versão do SEI:
 
 ```bash
 # Parar o ambiente atual
@@ -219,16 +219,16 @@ make down
 # (Opcional) Apagar dados do banco anterior
 make destroy
 
-# Trocar configuracao
+# Trocar configuração
 make config base=postgres-sei5
 
 # Subir com novo banco
 make up
 ```
 
-### Combinacoes Disponiveis
+### Combinações Disponíveis
 
-| Base | Banco | Versao SEI | Imagem |
+| Base | Banco | Versão SEI | Imagem |
 |------|-------|------------|--------|
 | `mysql-sei4` | MariaDB 10.5 | 4.0 | `mariadb10.5-sei40` |
 | `mysql-sei5` | MySQL 8 | 5.0 | `mysql8-sei50` |
@@ -241,15 +241,15 @@ make up
 
 ---
 
-## Atualizacao de Versao
+## Atualização de Versão
 
-Quando atualizar o codigo-fonte do SEI para uma nova versao, execute os scripts de atualizacao:
+Quando atualizar o código-fonte do SEI para uma nova versão, execute os scripts de atualização:
 
 ```bash
 make update
 ```
 
-Ou suba o ambiente ja executando o update:
+Ou suba o ambiente já executando o update:
 
 ```bash
 make up-update
@@ -262,15 +262,15 @@ Isso executa internamente:
 
 ---
 
-## Resolucao de Problemas
+## Resolução de Problemas
 
-### SEI nao inicia
+### SEI não inicia
 
 ```bash
-# Verificar se o caminho dos fontes esta correto
+# Verificar se o caminho dos fontes está correto
 make check-sei-path
 
-# Verificar se o Apache esta respondendo
+# Verificar se o Apache está respondendo
 make check-sei-ispinging
 
 # Verificar se o SEI responde com login
@@ -280,20 +280,20 @@ make check-sei-isalive
 docker logs httpd
 ```
 
-### Erro de conexao com banco
+### Erro de conexão com banco
 
 ```bash
-# Verificar se o container do banco esta rodando
+# Verificar se o container do banco está rodando
 docker ps | grep -E "mysql|postgres|oracle|sqlserver"
 
 # Ver logs do banco
 docker logs $(docker ps -qf "name=mysql\|postgres\|oracle\|sqlserver")
 ```
 
-### XDebug nao conecta
+### XDebug não conecta
 
-1. Verificar se `HOST_IP` esta definido corretamente
-2. Verificar se a porta 9003 esta aberta no firewall do host
+1. Verificar se `HOST_IP` está definido corretamente
+2. Verificar se a porta 9003 está aberta no firewall do host
 3. Testar com: `XDEBUG_MODE=debug,develop` para mensagens de erro detalhadas
 4. No WSL2, verificar regra de firewall do Windows
 

--- a/docs/guia-de-uso.md
+++ b/docs/guia-de-uso.md
@@ -1,0 +1,775 @@
+# Guia de Uso - SEI-Docker
+
+Guia completo e unificado para instalacao, configuracao e uso do SEI-Docker em todas as suas modalidades: desenvolvimento, infraestrutura e build de containers.
+
+---
+
+## Indice
+
+1. [Pre-requisitos](#1-pre-requisitos)
+2. [Obter o Codigo-Fonte do SEI](#2-obter-o-codigo-fonte-do-sei)
+3. [Inicio Rapido - Ambiente de Desenvolvimento](#3-inicio-rapido---ambiente-de-desenvolvimento)
+4. [Inicio Rapido - Infraestrutura Completa](#4-inicio-rapido---infraestrutura-completa)
+5. [Configuracao do envlocal.env](#5-configuracao-do-envlocalenv)
+6. [Comandos Make - Referencia Rapida](#6-comandos-make---referencia-rapida)
+7. [Acessando o SEI e Servicos](#7-acessando-o-sei-e-servicos)
+8. [Trocar Banco de Dados](#8-trocar-banco-de-dados)
+9. [Habilitar Servicos Opcionais](#9-habilitar-servicos-opcionais)
+10. [Escalar a Aplicacao](#10-escalar-a-aplicacao)
+11. [Alterar URL e Dominio](#11-alterar-url-e-dominio)
+12. [Instalar Modulos](#12-instalar-modulos)
+13. [Usar HTTPS com Certificado Proprio](#13-usar-https-com-certificado-proprio)
+14. [Kubernetes](#14-kubernetes)
+15. [Build de Imagens Customizadas](#15-build-de-imagens-customizadas)
+16. [Credenciais Padrao](#16-credenciais-padrao)
+17. [Resolucao de Problemas](#17-resolucao-de-problemas)
+18. [Video Tutoriais](#18-video-tutoriais)
+19. [Dicas e Boas Praticas](#19-dicas-e-boas-praticas)
+
+---
+
+## 1. Pre-requisitos
+
+### Sistema Operacional
+- Linux (recomendado) ou macOS
+- Windows com WSL2
+
+### Software
+
+| Software | Versao Minima | Verificar |
+|----------|--------------|-----------|
+| Docker Engine | 20+ | `docker --version` |
+| Docker Compose | v2+ | `docker compose version` |
+| GNU Make | qualquer | `make --version` |
+| envsubst | qualquer | `envsubst --version` |
+| curl | qualquer | `curl --version` |
+| Git | qualquer | `git --version` |
+
+### Obrigatorio
+- **Codigo-fonte do SEI** (propriedade do TRF4, obtido separadamente via [processoeletronico.gov.br](http://processoeletronico.gov.br))
+
+> **Atencao:** O codigo-fonte do SEI e propriedade do TRF4. Sob nenhuma hipotese deve ser distribuido, emprestado ou salvo em qualquer lugar que nao seja privativo da TI do orgao.
+
+---
+
+## 2. Obter o Codigo-Fonte do SEI
+
+O codigo-fonte deve estar organizado na seguinte estrutura:
+
+```
+~/sei/FonteSEI/
+├── sei/
+│   ├── web/
+│   ├── scripts/
+│   └── ...
+├── sip/
+│   ├── web/
+│   └── ...
+└── infra/
+    └── ...
+```
+
+Defina o caminho como variavel de ambiente:
+```bash
+export SEI_PATH=~/sei/FonteSEI
+```
+
+---
+
+## 3. Inicio Rapido - Ambiente de Desenvolvimento
+
+O ambiente **dev** e a forma mais simples de subir o SEI localmente, com XDebug habilitado e codigo-fonte montado para edicao ao vivo.
+
+### Passo a passo
+
+```bash
+# 1. Clonar o projeto
+git clone https://github.com/pengovbr/sei-docker.git
+cd sei-docker/dev
+
+# 2. Definir caminho do codigo-fonte
+export SEI_PATH=~/sei/FonteSEI
+
+# 3. Subir o ambiente (MySQL como padrao)
+make up
+```
+
+### Acessar
+
+| Servico | URL | Credenciais |
+|---------|-----|-------------|
+| SEI | http://localhost:8000/sei | `teste` / `teste` |
+| SIP | http://localhost:8000/sip | `teste` / `teste` |
+| MailCatcher | http://localhost:1080 | -- |
+| Solr Admin | http://localhost:8983/solr | -- |
+| Memcached | localhost:11211 | -- |
+
+### Parar e destruir
+
+```bash
+# Parar (preserva dados)
+make down
+
+# Parar e apagar tudo (volumes inclusos)
+make destroy
+
+# Reiniciar
+make restart
+```
+
+### Trocar banco no dev
+
+```bash
+make destroy
+make config base=postgres-sei5
+make up
+```
+
+Opcoes: `mysql-sei4`, `mysql-sei5`, `oracle-sei4`, `oracle-sei5`, `postgres-sei4`, `postgres-sei5`, `sqlserver-sei4`, `sqlserver-sei5`
+
+---
+
+## 4. Inicio Rapido - Infraestrutura Completa
+
+O ambiente **infra** e a forma completa de provisionar o SEI com todos os servicos, load balancer, HTTPS e possibilidade de escalonamento.
+
+### Passo a passo
+
+```bash
+# 1. Clonar o projeto
+git clone https://github.com/pengovbr/sei-docker.git
+cd sei-docker/infra
+
+# 2. Verificar e ajustar a variavel LOCALIZACAO_FONTES_SEI no envlocal.env
+#    Apontar para o diretorio onde esta o codigo-fonte do SEI
+vi envlocal.env
+
+# 3. Subir tudo com um unico comando
+make setup
+```
+
+O `make setup` executa automaticamente:
+1. Valida compatibilidade de versao
+2. Cria todos os volumes Docker necessarios
+3. Gera o `docker-compose.yml` a partir do template
+4. Sobe todos os servicos
+
+### Acessar
+
+Com a configuracao padrao (`APP_HOST=localhost`, `APP_PROTOCOLO=https`):
+
+| Servico | URL |
+|---------|-----|
+| SEI | https://localhost/sei |
+| SIP | https://localhost/sip |
+| Traefik Dashboard | https://localhost/traefik |
+
+### Parar e limpar
+
+```bash
+# Parar (preserva volumes/dados)
+make clear
+
+# Apagar TUDO (volumes inclusos - DESTRUTIVO)
+make apagar_volumes
+```
+
+> **Importante:** Antes de rodar `make run` ou `make setup` apos alterar o `envlocal.env`, sempre rode `make clear` primeiro. Isso evita servicos orfaos rodando quando se remove servicos da configuracao.
+
+---
+
+## 5. Configuracao do envlocal.env
+
+O arquivo `infra/envlocal.env` e o coracao da configuracao. Ele contem 100+ variaveis que controlam todo o ambiente.
+
+### Abordagem recomendada
+
+> **Nao altere tudo de uma vez.** Suba primeiro com as configuracoes padrao. Teste. Depois desligue, altere um parametro, suba novamente. Repita ate compreender todo o ecossistema.
+
+### Variaveis mais importantes para comecar
+
+| Variavel | O que faz | Padrao |
+|----------|-----------|--------|
+| `LOCALIZACAO_FONTES_SEI` | Caminho do codigo-fonte no host | `~/sei/FonteSEI` |
+| `LOCALIZACAO_CERTS` | Caminho dos certificados SSL | `~/sei/certs` |
+| `APP_PROTOCOLO` | `http` ou `https` | `https` |
+| `APP_HOST` | Hostname/URL do SEI | `localhost` |
+| `APP_ORGAO` | Sigla do orgao | `ME` |
+| `APP_ORGAO_DESCRICAO` | Nome completo do orgao | `Orgao Processo Eletronico - MySql` |
+| `APP_DB_TIPO` | Tipo do banco | `MySql` |
+| `DOCKER_IMAGE_BD` | Imagem do banco de dados | `processoeletronico/mariadb10.5-sei40:latest` |
+
+Para a referencia completa de todas as variaveis, consulte [variaveis-ambiente.md](variaveis-ambiente.md).
+
+---
+
+## 6. Comandos Make - Referencia Rapida
+
+### Ambiente Dev (`cd dev`)
+
+| Comando | Descricao |
+|---------|-----------|
+| `make help` | Lista todos os comandos |
+| `make up` | Sobe o ambiente |
+| `make up-update` | Sobe e executa scripts de atualizacao |
+| `make update` | Executa scripts de atualizacao do SEI/SIP |
+| `make config base=X` | Troca banco/versao |
+| `make down` | Para o ambiente (preserva volumes) |
+| `make restart` | Para e sobe novamente |
+| `make destroy` | Para e apaga tudo (DESTRUTIVO) |
+| `make check-sei-path` | Verifica codigo-fonte |
+| `make check-sei-isalive` | Verifica se SEI responde |
+
+### Infraestrutura (`cd infra`)
+
+| Comando | Descricao |
+|---------|-----------|
+| `make help` | Lista todos os comandos |
+| `make setup` | Setup completo (volumes + run) |
+| `make run` | Gera docker-compose e sobe |
+| `make build_docker_compose` | Apenas gera o docker-compose.yml |
+| `make criar_volumes` | Cria todos os volumes |
+| `make scale` | Escala app para 2 nos |
+| `make scale qtd=N` | Escala app para N nos |
+| `make stop` | Para containers |
+| `make clear` | Para e remove containers (preserva volumes) |
+| `make apagar_volumes` | Apaga TODOS os volumes (DESTRUTIVO) |
+| `make logs` | Logs de todos os servicos |
+| `make logs_app` | Logs da aplicacao |
+| `make logs_balanceador` | Logs do Traefik |
+| `make check-sei-isalive` | Verifica se SEI responde |
+
+### Build de Containers (`cd containers`)
+
+| Comando | Descricao |
+|---------|-----------|
+| `make help` | Lista todos os comandos |
+| `make getenv` | Cria envcontainers.env a partir do modelo |
+| `make build-conteiners` | Build de todas as imagens |
+| `make erase-conteiners-local` | Apaga todas as imagens locais |
+| `make publish-containers` | Publica todas no registry |
+
+---
+
+## 7. Acessando o SEI e Servicos
+
+### Infraestrutura (com load balancer)
+
+Todos os servicos sao acessados pela mesma URL base (definida em `APP_HOST`):
+
+| Servico | Caminho | Toggle |
+|---------|---------|--------|
+| SEI | `/sei` | sempre ativo |
+| SIP | `/sip` | sempre ativo |
+| Traefik Dashboard | `/traefik` | `BALANCEADOR_PRESENTE=true` |
+| Solr Admin | `/solr` | sempre ativo |
+| Memcached Admin | `/memcachedadmin` | `MEMCACHEDADMIN_PRESENTE=true` |
+| Database Admin | `/dbadmin` | `DBADMIN_PRESENTE=true` |
+| MailCatcher | `/mailadmin` | `MAIL_CATCHER_PRESENTE=true` |
+| phpLDAPadmin | `/phpldapadmin` | `OPENLDAP_PRESENTE=true` |
+
+Exemplo com `APP_HOST=sei.treinamento.gov.br`:
+- SEI: `https://sei.treinamento.gov.br/sei`
+- Solr: `https://sei.treinamento.gov.br/solr`
+
+### Desenvolvimento (sem load balancer)
+
+| Servico | URL |
+|---------|-----|
+| SEI | http://localhost:8000/sei |
+| SIP | http://localhost:8000/sip |
+| MailCatcher | http://localhost:1080 |
+| Solr | http://localhost:8983/solr |
+| Banco MySQL | localhost:3306 |
+| Banco PostgreSQL | localhost:5432 |
+| Banco Oracle | localhost:1521 |
+| Banco SQL Server | localhost:1433 |
+
+---
+
+## 8. Trocar Banco de Dados
+
+### No ambiente dev
+
+```bash
+cd dev
+make destroy                    # Apagar ambiente atual
+make config base=postgres-sei5  # Trocar para PostgreSQL + SEI 5
+make up                         # Subir com novo banco
+```
+
+### No ambiente infra
+
+Edite `infra/envlocal.env` e altere:
+
+```bash
+# Para MySQL 8 + SEI 5.0
+APP_DB_TIPO=MySql
+APP_DB_PORTA=3306
+DOCKER_IMAGE_BD=${DOCKER_REGISTRY}/mysql8-sei50:latest
+
+# Para PostgreSQL + SEI 5.0
+APP_DB_TIPO=PostgreSql
+APP_DB_PORTA=5432
+DOCKER_IMAGE_BD=${DOCKER_REGISTRY}/postgres15-sei50:latest
+
+# Para Oracle + SEI 4.1
+APP_DB_TIPO=Oracle
+APP_DB_PORTA=1521
+DOCKER_IMAGE_BD=${DOCKER_REGISTRY}/oracle11g-sei41:latest
+
+# Para SQL Server + SEI 4.1
+APP_DB_TIPO=SqlServer
+APP_DB_PORTA=1433
+DOCKER_IMAGE_BD=${DOCKER_REGISTRY}/sqlserver2019-sei41:latest
+```
+
+Depois:
+```bash
+make clear
+make apagar_volumes
+make setup
+```
+
+### Imagens de banco disponiveis
+
+| Imagem | Banco | Versao SEI |
+|--------|-------|------------|
+| `mariadb10.5-sei40` | MariaDB 10.5 | 4.0 |
+| `mariadb10.5-sei41` | MariaDB 10.5 | 4.1 |
+| `mariadb10.5-sei50` | MariaDB 10.5 | 5.0 |
+| `mysql8-sei41` | MySQL 8 | 4.1 |
+| `mysql8-sei50` | MySQL 8 | 5.0 |
+| `postgres15-sei40` | PostgreSQL 15 | 4.0 |
+| `postgres15-sei41` | PostgreSQL 15 | 4.1 |
+| `postgres15-sei50` | PostgreSQL 15 | 5.0 |
+| `oracle11g-sei40` | Oracle 11g | 4.0 |
+| `oracle11g-sei41` | Oracle 11g | 4.1 |
+| `oracle11g-sei50` | Oracle 11g | 5.0 |
+| `sqlserver2019-sei40` | SQL Server 2019 | 4.0 |
+| `sqlserver2019-sei41` | SQL Server 2019 | 4.1 |
+| `sqlserver2019-sei50` | SQL Server 2019 | 5.0 |
+
+---
+
+## 9. Habilitar Servicos Opcionais
+
+Edite `infra/envlocal.env` e altere os toggles:
+
+```bash
+# Converter documentos (LibreOffice)
+JOD_PRESENTE=true
+
+# Captura de e-mails (teste)
+MAIL_CATCHER_PRESENTE=true
+
+# Administracao do banco via web
+DBADMIN_PRESENTE=true
+
+# Administracao do cache
+MEMCACHEDADMIN_PRESENTE=true
+
+# Diretorio LDAP (autenticacao)
+OPENLDAP_PRESENTE=true
+
+# Load balancer Traefik
+BALANCEADOR_PRESENTE=true
+```
+
+Depois aplique:
+```bash
+make clear
+make run
+```
+
+> Quando `OPENLDAP_PRESENTE=true`, o SEI passa a usar autenticacao LDAP automaticamente. Um usuario de teste com senha `123456` e criado. Para voltar ao login padrao, configure `OPENLDAP_PRESENTE=false` e `OPENLDAP_DESLIGAR_NO_ORGAO_0=true`, rode `make run`, depois volte `OPENLDAP_DESLIGAR_NO_ORGAO_0=false`.
+
+---
+
+## 10. Escalar a Aplicacao
+
+O SEI pode ser escalado horizontalmente (multiplos nos de aplicacao atras do Traefik):
+
+```bash
+cd infra
+
+# Escalar para 2 nos (padrao)
+make scale
+
+# Escalar para 3 nos
+make scale qtd=3
+
+# Voltar para 1 no
+make scale qtd=1
+```
+
+> Para balanceamento sem sticky session, habilite sessoes no Memcached: `APP_MEMCACHED_SESSION=true` (requer SEI 5+).
+
+---
+
+## 11. Alterar URL e Dominio
+
+### Trocar de localhost para um dominio personalizado
+
+1. Pare o projeto:
+```bash
+make clear
+make apagar_volumes
+```
+
+2. Edite `envlocal.env`:
+```bash
+APP_HOST=sei.treinamento.orgao.gov.br
+APP_PROTOCOLO=https
+```
+
+3. Configure DNS ou `/etc/hosts`:
+```bash
+# /etc/hosts
+192.168.1.100  sei.treinamento.orgao.gov.br
+```
+
+4. Suba novamente:
+```bash
+make setup
+```
+
+> **Importante:** Ao mudar o hostname, apague os volumes pois a URL fica gravada no banco de dados. O `make setup` recria tudo com a nova URL.
+
+---
+
+## 12. Instalar Modulos
+
+Cada modulo e controlado por variaveis `MODULO_*_INSTALAR` e `MODULO_*_VERSAO` no `envlocal.env`.
+
+### Exemplo: Habilitar modulo de Estatisticas
+
+```bash
+MODULO_ESTATISTICAS_INSTALAR=true
+MODULO_ESTATISTICAS_VERSAO=master
+```
+
+### Exemplo: Habilitar modulo PEN (tramitacao entre orgaos)
+
+```bash
+MODULO_PEN_INSTALAR=true
+MODULO_PEN_VERSAO=master
+MODULO_PEN_WEBSERVICE=https://homolog.api.processoeletronico.gov.br/interoperabilidade/soap/v3/
+MODULO_PEN_CERTIFICADO_SENHA=1234
+MODULO_PEN_CERTIFICADO_BASE64=<certificado em base64>
+```
+
+### Modulos disponiveis
+
+| Modulo | Variavel | Funcao |
+|--------|----------|--------|
+| Estatisticas | `MODULO_ESTATISTICAS_INSTALAR` | Painel de estatisticas |
+| REST / WSSEI | `MODULO_REST_INSTALAR` | API REST |
+| Gestao Documental | `MODULO_GESTAODOCUMENTAL_INSTALAR` | Gestao do ciclo de vida |
+| Resposta | `MODULO_RESPOSTA_INSTALAR` | Respostas a demandas |
+| Login Unico | `MODULO_LOGINUNICO_INSTALAR` | SSO GOV.BR |
+| Assinatura | `MODULO_ASSINATURA_INSTALAR` | Assinatura digital ICP-Brasil |
+| PEN | `MODULO_PEN_INSTALAR` | Tramitacao entre orgaos |
+| Peticionamento | `MODULO_PETICIONAMENTO_INSTALAR` | Peticionamento eletronico |
+| Protocolo Integrado | `MODULO_PI_INSTALAR` | Integracao Protocolo.GOV.BR |
+| INCOM | `MODULO_INCOM_INSTALAR` | Publicacao na Imprensa Nacional |
+
+Para detalhes de cada modulo e suas variaveis, consulte [variaveis-ambiente.md](variaveis-ambiente.md).
+
+Apos alterar modulos:
+```bash
+make clear
+make run
+```
+
+O container `app-atualizador` detecta e instala automaticamente os modulos habilitados.
+
+---
+
+## 13. Usar HTTPS com Certificado Proprio
+
+### Certificado auto-assinado (padrao)
+
+Por padrao, o projeto gera certificados auto-assinados automaticamente. Basta:
+```bash
+APP_PROTOCOLO=https
+```
+
+### Certificado proprio
+
+1. Crie o diretorio de certificados definido em `LOCALIZACAO_CERTS`:
+```bash
+mkdir -p ~/sei/certs
+```
+
+2. Copie seus arquivos de certificado para esse diretorio
+
+3. Configure no `envlocal.env`:
+```bash
+LOCALIZACAO_CERTS=~/sei/certs
+APP_PROTOCOLO=https
+```
+
+### Usar HTTP (sem TLS)
+
+```bash
+APP_PROTOCOLO=http
+```
+
+---
+
+## 14. Kubernetes
+
+O projeto gera manifests Kubernetes a partir dos templates.
+
+### Gerar manifests
+
+```bash
+cd infra
+
+# Ajuste as variaveis KUBERNETES_* no envlocal.env
+vi envlocal.env
+
+# Gerar YAML
+make kubernetes_montar_yaml
+```
+
+Os arquivos sao gerados em `infra/orquestrators/rancher-kubernetes/topublish/`.
+
+### Aplicar no cluster
+
+```bash
+make kubernetes_apply
+```
+
+### Remover do cluster
+
+```bash
+make kubernetes_delete
+```
+
+### Configuracao Kubernetes no envlocal.env
+
+```bash
+KUBERNETES_NAMESPACE=seins
+KUBERNETES_PVC_STORAGECLASS=nfs-client
+KUBERNETES_RESOURCES_INFORMAR=true
+KUBERNETES_LIMITS_MEMORY_APP=1Gi
+KUBERNETES_LIMITS_CPU_APP=500m
+# ... (ver variaveis-ambiente.md para lista completa)
+```
+
+> **Nota:** A geracao Kubernetes atualmente funciona apenas para MySQL. O codigo-fonte do SEI deve ser movido manualmente para o PVC `vol-sei-fontes`.
+
+---
+
+## 15. Build de Imagens Customizadas
+
+Se voce deseja buildar suas proprias imagens ou usar seu proprio registry:
+
+```bash
+cd containers
+
+# Criar arquivo de configuracao
+make getenv
+
+# Editar envcontainers.env
+vi envcontainers.env
+# Altere DOCKER_REGISTRY para o seu registry
+
+# Build de todas as imagens
+make build-conteiners
+
+# Ou build individual
+make build-conteiner-base-rocky93
+make build-conteiner-app-ci-php8
+make build-conteiner-mysql8-sei50
+
+# Publicar no registry
+make publish-containers
+```
+
+> Se alterar `DOCKER_REGISTRY` ou `DOCKER_CONTAINER_VERSAO_PRODUTO` nos containers, replique as alteracoes nos envfiles de `dev/` e `infra/`.
+
+---
+
+## 16. Credenciais Padrao
+
+### Aplicacao SEI/SIP
+
+| Campo | Valor |
+|-------|-------|
+| Usuario | `teste` |
+| Senha | `teste` |
+
+### Bancos de Dados
+
+#### MySQL / MariaDB
+| Usuario | Login | Senha |
+|---------|-------|-------|
+| Root | `root` | `P@ssword` |
+| SEI | `sei_user` | `sei_user` |
+| SIP | `sip_user` | `sip_user` |
+
+Acesso: `mysql -h 127.0.0.1 -u root -p sei`
+
+#### PostgreSQL
+| Usuario | Login | Senha |
+|---------|-------|-------|
+| Root | `postgres` | `P@ssword` |
+| SEI | `sei_user` | `sei_user` |
+| SIP | `sip_user` | `sip_user` |
+
+#### Oracle
+| Usuario | Login | Senha |
+|---------|-------|-------|
+| SYS | `sys` | `P@ssword` |
+| System | `system` | `P@ssword` |
+| SEI | `sei` | `sei_user` |
+| SIP | `sip` | `sip_user` |
+
+Acesso: `sqlplus sys/P@ssword as sysdba`
+
+#### SQL Server
+| Usuario | Login | Senha |
+|---------|-------|-------|
+| SA | `sa` | `yourStrong(!)Password` |
+| SEI | `sei_user` | `sei_user` |
+| SIP | `sip_user` | `sip_user` |
+
+Acesso: `tsql -S 127.0.0.1 -U sa -P 'yourStrong(!)Password'`
+
+### OpenLDAP
+| Campo | Valor |
+|-------|-------|
+| Admin DN | `cn=admin,dc=pen,dc=gov,dc=br` |
+| Senha | `adminldap` |
+| Usuario teste | senha `123456` |
+
+---
+
+## 17. Resolucao de Problemas
+
+### Portas ocupadas
+
+Antes de subir, verifique se as portas estao livres:
+
+```bash
+# Infra
+sudo lsof -i :80    # HTTP
+sudo lsof -i :443   # HTTPS
+
+# Dev
+sudo lsof -i :8000  # App
+sudo lsof -i :1080  # MailCatcher
+sudo lsof -i :8983  # Solr
+sudo lsof -i :3306  # MySQL
+```
+
+Se alguma porta estiver ocupada, pare o servico ou altere o mapeamento no `envlocal.env`.
+
+### SEI nao inicia / tela em branco
+
+```bash
+# Verificar se SEI responde
+make check-sei-isalive
+
+# Ver logs da aplicacao
+make logs_app
+
+# Ver logs do atualizador (instalacao de modulos)
+make logs_app-atualizador
+
+# Ver todos os logs
+make logs
+```
+
+### Servicos orfaos apos mudanca de configuracao
+
+```bash
+# Sempre rode clear antes de alterar envlocal.env
+make clear
+# Agora edite envlocal.env
+make run
+```
+
+### Container do banco nao inicia
+
+```bash
+# Ver logs do banco
+docker logs $(docker ps -aqf "name=db" | head -1)
+
+# Recriar volume do banco (perde dados)
+make apagar_volume_banco
+make criar_volume_banco
+make run
+```
+
+### Recomecar do zero
+
+```bash
+cd infra
+make clear
+make apagar_volumes
+# Edite envlocal.env se necessario
+make setup
+```
+
+### Versao incompativel
+
+```bash
+# Verificar compatibilidade
+make check-version-compatibility
+```
+
+O projeto valida se a versao do codigo-fonte e compativel com as imagens Docker.
+
+### Docker Compose v1 vs v2
+
+O projeto detecta automaticamente. Se tiver problemas:
+```bash
+# Verificar qual esta instalado
+docker compose version    # v2
+docker-compose --version  # v1
+```
+
+---
+
+## 18. Video Tutoriais
+
+Videos gravados pela equipe do projeto com orientacoes praticas:
+
+| Video | Conteudo | Link |
+|-------|----------|------|
+| Infra Reduzida Rapidamente | Subida basica em localhost com HTTPS | [Assistir](https://www.youtube.com/watch?v=FwPp9lZiHuM) |
+| Infra Completa Rapidamente | Todos os componentes, domain name, HTTPS | [Assistir](https://www.youtube.com/watch?v=MpTLtDlSVLw) |
+| SqlServer ou Oracle | Como usar bancos alternativos | [Assistir](https://www.youtube.com/watch?v=IgEiR5CZEEs) |
+| Organizacao do Projeto | Estrutura tecnica e anatomia da solucao | [Assistir](https://www.youtube.com/watch?v=rczbANlWVRY) |
+| Customizacoes Basicas | Trocar hostname, Solr admin, scale | [Assistir](https://www.youtube.com/watch?v=HjZfryu0sco) |
+| Customizacoes Completas | Todos os componentes, LDAP, orientacoes avancadas | [Assistir](https://www.youtube.com/watch?v=m5wXBPDMVQQ) |
+
+> Recomendado assistir na ordem listada acima.
+
+---
+
+## 19. Dicas e Boas Praticas
+
+1. **Comece simples.** Suba com as configuracoes padrao primeiro. Teste. Depois va customizando um parametro por vez.
+
+2. **Sempre `make clear` antes de alterar.** Evita servicos orfaos e conflitos.
+
+3. **Nao altere o envlocal.env inteiro de uma vez.** Altere um parametro, suba, teste, repita.
+
+4. **Volumes sao seus dados.** `make apagar_volumes` apaga banco de dados, arquivos anexados, indices Solr. Use com cuidado.
+
+5. **`make clear` e seguro.** Remove apenas containers e redes, nunca dados.
+
+6. **Verifique portas antes de subir.** Portas 80 e 443 (infra) ou 8000 (dev) devem estar livres.
+
+7. **Use `make help`.** Todos os Makefiles possuem ajuda embutida com descricao de cada comando.
+
+8. **DNS ou /etc/hosts.** Ao usar um dominio customizado, garanta que o DNS ou `/etc/hosts` aponte para a maquina correta.
+
+9. **Backup dos volumes.** Em ambiente de teste/treinamento, faca backup do volume do banco (`VOLUME_DB`) e dos arquivos externos (`VOLUME_ARQUIVOSEXTERNOS`).
+
+10. **Nao e para producao.** O projeto e para DTH. Producao requer hardening de seguranca, firewall, backup e configuracoes adicionais conforme documentacao do TRF e PEN.

--- a/docs/guia-de-uso.md
+++ b/docs/guia-de-uso.md
@@ -1,34 +1,34 @@
 # Guia de Uso - SEI-Docker
 
-Guia completo e unificado para instalacao, configuracao e uso do SEI-Docker em todas as suas modalidades: desenvolvimento, infraestrutura e build de containers.
+Guia completo e unificado para instalação, configuração e uso do SEI-Docker em todas as suas modalidades: desenvolvimento, infraestrutura e build de containers.
 
 ---
 
-## Indice
+## Índice
 
-1. [Pre-requisitos](#1-pre-requisitos)
-2. [Obter o Codigo-Fonte do SEI](#2-obter-o-codigo-fonte-do-sei)
-3. [Inicio Rapido - Ambiente de Desenvolvimento](#3-inicio-rapido---ambiente-de-desenvolvimento)
-4. [Inicio Rapido - Infraestrutura Completa](#4-inicio-rapido---infraestrutura-completa)
-5. [Configuracao do envlocal.env](#5-configuracao-do-envlocalenv)
-6. [Comandos Make - Referencia Rapida](#6-comandos-make---referencia-rapida)
-7. [Acessando o SEI e Servicos](#7-acessando-o-sei-e-servicos)
+1. [Pré-requisitos](#1-pré-requisitos)
+2. [Obter o Código-Fonte do SEI](#2-obter-o-código-fonte-do-sei)
+3. [Início Rápido - Ambiente de Desenvolvimento](#3-início-rápido---ambiente-de-desenvolvimento)
+4. [Início Rápido - Infraestrutura Completa](#4-início-rápido---infraestrutura-completa)
+5. [Configuração do envlocal.env](#5-configuração-do-envlocalenv)
+6. [Comandos Make - Referência Rápida](#6-comandos-make---referência-rápida)
+7. [Acessando o SEI e Serviços](#7-acessando-o-sei-e-serviços)
 8. [Trocar Banco de Dados](#8-trocar-banco-de-dados)
-9. [Habilitar Servicos Opcionais](#9-habilitar-servicos-opcionais)
-10. [Escalar a Aplicacao](#10-escalar-a-aplicacao)
-11. [Alterar URL e Dominio](#11-alterar-url-e-dominio)
-12. [Instalar Modulos](#12-instalar-modulos)
-13. [Usar HTTPS com Certificado Proprio](#13-usar-https-com-certificado-proprio)
+9. [Habilitar Serviços Opcionais](#9-habilitar-serviços-opcionais)
+10. [Escalar a Aplicação](#10-escalar-a-aplicação)
+11. [Alterar URL e Domínio](#11-alterar-url-e-domínio)
+12. [Instalar Módulos](#12-instalar-módulos)
+13. [Usar HTTPS com Certificado Próprio](#13-usar-https-com-certificado-próprio)
 14. [Kubernetes](#14-kubernetes)
 15. [Build de Imagens Customizadas](#15-build-de-imagens-customizadas)
-16. [Credenciais Padrao](#16-credenciais-padrao)
-17. [Resolucao de Problemas](#17-resolucao-de-problemas)
-18. [Video Tutoriais](#18-video-tutoriais)
-19. [Dicas e Boas Praticas](#19-dicas-e-boas-praticas)
+16. [Credenciais Padrão](#16-credenciais-padrão)
+17. [Resolução de Problemas](#17-resolução-de-problemas)
+18. [Vídeo Tutoriais](#18-vídeo-tutoriais)
+19. [Dicas e Boas Práticas](#19-dicas-e-boas-práticas)
 
 ---
 
-## 1. Pre-requisitos
+## 1. Pré-requisitos
 
 ### Sistema Operacional
 - Linux (recomendado) ou macOS
@@ -36,7 +36,7 @@ Guia completo e unificado para instalacao, configuracao e uso do SEI-Docker em t
 
 ### Software
 
-| Software | Versao Minima | Verificar |
+| Software | Versão Mínima | Verificar |
 |----------|--------------|-----------|
 | Docker Engine | 20+ | `docker --version` |
 | Docker Compose | v2+ | `docker compose version` |
@@ -45,16 +45,16 @@ Guia completo e unificado para instalacao, configuracao e uso do SEI-Docker em t
 | curl | qualquer | `curl --version` |
 | Git | qualquer | `git --version` |
 
-### Obrigatorio
-- **Codigo-fonte do SEI** (propriedade do TRF4, obtido separadamente via [processoeletronico.gov.br](http://processoeletronico.gov.br))
+### Obrigatório
+- **Código-fonte do SEI** (propriedade do TRF4, obtido separadamente via [processoeletronico.gov.br](http://processoeletronico.gov.br))
 
-> **Atencao:** O codigo-fonte do SEI e propriedade do TRF4. Sob nenhuma hipotese deve ser distribuido, emprestado ou salvo em qualquer lugar que nao seja privativo da TI do orgao.
+> **Atenção:** O código-fonte do SEI é propriedade do TRF4. Sob nenhuma hipótese deve ser distribuído, emprestado ou salvo em qualquer lugar que não seja privativo da TI do órgão.
 
 ---
 
-## 2. Obter o Codigo-Fonte do SEI
+## 2. Obter o Código-Fonte do SEI
 
-O codigo-fonte deve estar organizado na seguinte estrutura:
+O código-fonte deve estar organizado na seguinte estrutura:
 
 ```
 ~/sei/FonteSEI/
@@ -69,16 +69,16 @@ O codigo-fonte deve estar organizado na seguinte estrutura:
     └── ...
 ```
 
-Defina o caminho como variavel de ambiente:
+Defina o caminho como variável de ambiente:
 ```bash
 export SEI_PATH=~/sei/FonteSEI
 ```
 
 ---
 
-## 3. Inicio Rapido - Ambiente de Desenvolvimento
+## 3. Início Rápido - Ambiente de Desenvolvimento
 
-O ambiente **dev** e a forma mais simples de subir o SEI localmente, com XDebug habilitado e codigo-fonte montado para edicao ao vivo.
+O ambiente **dev** é a forma mais simples de subir o SEI localmente, com XDebug habilitado e código-fonte montado para edição ao vivo.
 
 ### Passo a passo
 
@@ -87,16 +87,16 @@ O ambiente **dev** e a forma mais simples de subir o SEI localmente, com XDebug 
 git clone https://github.com/pengovbr/sei-docker.git
 cd sei-docker/dev
 
-# 2. Definir caminho do codigo-fonte
+# 2. Definir caminho do código-fonte
 export SEI_PATH=~/sei/FonteSEI
 
-# 3. Subir o ambiente (MySQL como padrao)
+# 3. Subir o ambiente (MySQL como padrão)
 make up
 ```
 
 ### Acessar
 
-| Servico | URL | Credenciais |
+| Serviço | URL | Credenciais |
 |---------|-----|-------------|
 | SEI | http://localhost:8000/sei | `teste` / `teste` |
 | SIP | http://localhost:8000/sip | `teste` / `teste` |
@@ -125,13 +125,13 @@ make config base=postgres-sei5
 make up
 ```
 
-Opcoes: `mysql-sei4`, `mysql-sei5`, `oracle-sei4`, `oracle-sei5`, `postgres-sei4`, `postgres-sei5`, `sqlserver-sei4`, `sqlserver-sei5`
+Opções: `mysql-sei4`, `mysql-sei5`, `oracle-sei4`, `oracle-sei5`, `postgres-sei4`, `postgres-sei5`, `sqlserver-sei4`, `sqlserver-sei5`
 
 ---
 
-## 4. Inicio Rapido - Infraestrutura Completa
+## 4. Início Rápido - Infraestrutura Completa
 
-O ambiente **infra** e a forma completa de provisionar o SEI com todos os servicos, load balancer, HTTPS e possibilidade de escalonamento.
+O ambiente **infra** é a forma completa de provisionar o SEI com todos os serviços, load balancer, HTTPS e possibilidade de escalonamento.
 
 ### Passo a passo
 
@@ -140,25 +140,25 @@ O ambiente **infra** e a forma completa de provisionar o SEI com todos os servic
 git clone https://github.com/pengovbr/sei-docker.git
 cd sei-docker/infra
 
-# 2. Verificar e ajustar a variavel LOCALIZACAO_FONTES_SEI no envlocal.env
-#    Apontar para o diretorio onde esta o codigo-fonte do SEI
+# 2. Verificar e ajustar a variável LOCALIZACAO_FONTES_SEI no envlocal.env
+#    Apontar para o diretório onde está o código-fonte do SEI
 vi envlocal.env
 
-# 3. Subir tudo com um unico comando
+# 3. Subir tudo com um único comando
 make setup
 ```
 
 O `make setup` executa automaticamente:
-1. Valida compatibilidade de versao
-2. Cria todos os volumes Docker necessarios
+1. Valida compatibilidade de versão
+2. Cria todos os volumes Docker necessários
 3. Gera o `docker-compose.yml` a partir do template
-4. Sobe todos os servicos
+4. Sobe todos os serviços
 
 ### Acessar
 
-Com a configuracao padrao (`APP_HOST=localhost`, `APP_PROTOCOLO=https`):
+Com a configuração padrão (`APP_HOST=localhost`, `APP_PROTOCOLO=https`):
 
-| Servico | URL |
+| Serviço | URL |
 |---------|-----|
 | SEI | https://localhost/sei |
 | SIP | https://localhost/sip |
@@ -174,74 +174,74 @@ make clear
 make apagar_volumes
 ```
 
-> **Importante:** Antes de rodar `make run` ou `make setup` apos alterar o `envlocal.env`, sempre rode `make clear` primeiro. Isso evita servicos orfaos rodando quando se remove servicos da configuracao.
+> **Importante:** Antes de rodar `make run` ou `make setup` após alterar o `envlocal.env`, sempre rode `make clear` primeiro. Isso evita serviços órfãos rodando quando se remove serviços da configuração.
 
 ---
 
-## 5. Configuracao do envlocal.env
+## 5. Configuração do envlocal.env
 
-O arquivo `infra/envlocal.env` e o coracao da configuracao. Ele contem 100+ variaveis que controlam todo o ambiente.
+O arquivo `infra/envlocal.env` é o coração da configuração. Ele contém 100+ variáveis que controlam todo o ambiente.
 
 ### Abordagem recomendada
 
-> **Nao altere tudo de uma vez.** Suba primeiro com as configuracoes padrao. Teste. Depois desligue, altere um parametro, suba novamente. Repita ate compreender todo o ecossistema.
+> **Não altere tudo de uma vez.** Suba primeiro com as configurações padrão. Teste. Depois desligue, altere um parâmetro, suba novamente. Repita até compreender todo o ecossistema.
 
-### Variaveis mais importantes para comecar
+### Variáveis mais importantes para começar
 
-| Variavel | O que faz | Padrao |
+| Variável | O que faz | Padrão |
 |----------|-----------|--------|
-| `LOCALIZACAO_FONTES_SEI` | Caminho do codigo-fonte no host | `~/sei/FonteSEI` |
+| `LOCALIZACAO_FONTES_SEI` | Caminho do código-fonte no host | `~/sei/FonteSEI` |
 | `LOCALIZACAO_CERTS` | Caminho dos certificados SSL | `~/sei/certs` |
 | `APP_PROTOCOLO` | `http` ou `https` | `https` |
 | `APP_HOST` | Hostname/URL do SEI | `localhost` |
-| `APP_ORGAO` | Sigla do orgao | `ME` |
-| `APP_ORGAO_DESCRICAO` | Nome completo do orgao | `Orgao Processo Eletronico - MySql` |
+| `APP_ORGAO` | Sigla do órgão | `ME` |
+| `APP_ORGAO_DESCRICAO` | Nome completo do órgão | `Órgão Processo Eletrônico - MySql` |
 | `APP_DB_TIPO` | Tipo do banco | `MySql` |
 | `DOCKER_IMAGE_BD` | Imagem do banco de dados | `processoeletronico/mariadb10.5-sei40:latest` |
 
-Para a referencia completa de todas as variaveis, consulte [variaveis-ambiente.md](variaveis-ambiente.md).
+Para a referência completa de todas as variáveis, consulte [variaveis-ambiente.md](variaveis-ambiente.md).
 
 ---
 
-## 6. Comandos Make - Referencia Rapida
+## 6. Comandos Make - Referência Rápida
 
 ### Ambiente Dev (`cd dev`)
 
-| Comando | Descricao |
+| Comando | Descrição |
 |---------|-----------|
 | `make help` | Lista todos os comandos |
 | `make up` | Sobe o ambiente |
-| `make up-update` | Sobe e executa scripts de atualizacao |
-| `make update` | Executa scripts de atualizacao do SEI/SIP |
-| `make config base=X` | Troca banco/versao |
+| `make up-update` | Sobe e executa scripts de atualização |
+| `make update` | Executa scripts de atualização do SEI/SIP |
+| `make config base=X` | Troca banco/versão |
 | `make down` | Para o ambiente (preserva volumes) |
 | `make restart` | Para e sobe novamente |
 | `make destroy` | Para e apaga tudo (DESTRUTIVO) |
-| `make check-sei-path` | Verifica codigo-fonte |
+| `make check-sei-path` | Verifica código-fonte |
 | `make check-sei-isalive` | Verifica se SEI responde |
 
 ### Infraestrutura (`cd infra`)
 
-| Comando | Descricao |
+| Comando | Descrição |
 |---------|-----------|
 | `make help` | Lista todos os comandos |
 | `make setup` | Setup completo (volumes + run) |
 | `make run` | Gera docker-compose e sobe |
 | `make build_docker_compose` | Apenas gera o docker-compose.yml |
 | `make criar_volumes` | Cria todos os volumes |
-| `make scale` | Escala app para 2 nos |
-| `make scale qtd=N` | Escala app para N nos |
+| `make scale` | Escala app para 2 nós |
+| `make scale qtd=N` | Escala app para N nós |
 | `make stop` | Para containers |
 | `make clear` | Para e remove containers (preserva volumes) |
 | `make apagar_volumes` | Apaga TODOS os volumes (DESTRUTIVO) |
-| `make logs` | Logs de todos os servicos |
-| `make logs_app` | Logs da aplicacao |
+| `make logs` | Logs de todos os serviços |
+| `make logs_app` | Logs da aplicação |
 | `make logs_balanceador` | Logs do Traefik |
 | `make check-sei-isalive` | Verifica se SEI responde |
 
 ### Build de Containers (`cd containers`)
 
-| Comando | Descricao |
+| Comando | Descrição |
 |---------|-----------|
 | `make help` | Lista todos os comandos |
 | `make getenv` | Cria envcontainers.env a partir do modelo |
@@ -251,13 +251,13 @@ Para a referencia completa de todas as variaveis, consulte [variaveis-ambiente.m
 
 ---
 
-## 7. Acessando o SEI e Servicos
+## 7. Acessando o SEI e Serviços
 
 ### Infraestrutura (com load balancer)
 
-Todos os servicos sao acessados pela mesma URL base (definida em `APP_HOST`):
+Todos os serviços são acessados pela mesma URL base (definida em `APP_HOST`):
 
-| Servico | Caminho | Toggle |
+| Serviço | Caminho | Toggle |
 |---------|---------|--------|
 | SEI | `/sei` | sempre ativo |
 | SIP | `/sip` | sempre ativo |
@@ -274,7 +274,7 @@ Exemplo com `APP_HOST=sei.treinamento.gov.br`:
 
 ### Desenvolvimento (sem load balancer)
 
-| Servico | URL |
+| Serviço | URL |
 |---------|-----|
 | SEI | http://localhost:8000/sei |
 | SIP | http://localhost:8000/sip |
@@ -331,9 +331,9 @@ make apagar_volumes
 make setup
 ```
 
-### Imagens de banco disponiveis
+### Imagens de banco disponíveis
 
-| Imagem | Banco | Versao SEI |
+| Imagem | Banco | Versão SEI |
 |--------|-------|------------|
 | `mariadb10.5-sei40` | MariaDB 10.5 | 4.0 |
 | `mariadb10.5-sei41` | MariaDB 10.5 | 4.1 |
@@ -352,7 +352,7 @@ make setup
 
 ---
 
-## 9. Habilitar Servicos Opcionais
+## 9. Habilitar Serviços Opcionais
 
 Edite `infra/envlocal.env` e altere os toggles:
 
@@ -363,13 +363,13 @@ JOD_PRESENTE=true
 # Captura de e-mails (teste)
 MAIL_CATCHER_PRESENTE=true
 
-# Administracao do banco via web
+# Administração do banco via web
 DBADMIN_PRESENTE=true
 
-# Administracao do cache
+# Administração do cache
 MEMCACHEDADMIN_PRESENTE=true
 
-# Diretorio LDAP (autenticacao)
+# Diretório LDAP (autenticação)
 OPENLDAP_PRESENTE=true
 
 # Load balancer Traefik
@@ -382,34 +382,34 @@ make clear
 make run
 ```
 
-> Quando `OPENLDAP_PRESENTE=true`, o SEI passa a usar autenticacao LDAP automaticamente. Um usuario de teste com senha `123456` e criado. Para voltar ao login padrao, configure `OPENLDAP_PRESENTE=false` e `OPENLDAP_DESLIGAR_NO_ORGAO_0=true`, rode `make run`, depois volte `OPENLDAP_DESLIGAR_NO_ORGAO_0=false`.
+> Quando `OPENLDAP_PRESENTE=true`, o SEI passa a usar autenticação LDAP automaticamente. Um usuário de teste com senha `123456` é criado. Para voltar ao login padrão, configure `OPENLDAP_PRESENTE=false` e `OPENLDAP_DESLIGAR_NO_ORGAO_0=true`, rode `make run`, depois volte `OPENLDAP_DESLIGAR_NO_ORGAO_0=false`.
 
 ---
 
-## 10. Escalar a Aplicacao
+## 10. Escalar a Aplicação
 
-O SEI pode ser escalado horizontalmente (multiplos nos de aplicacao atras do Traefik):
+O SEI pode ser escalado horizontalmente (múltiplos nós de aplicação atrás do Traefik):
 
 ```bash
 cd infra
 
-# Escalar para 2 nos (padrao)
+# Escalar para 2 nós (padrão)
 make scale
 
-# Escalar para 3 nos
+# Escalar para 3 nós
 make scale qtd=3
 
-# Voltar para 1 no
+# Voltar para 1 nó
 make scale qtd=1
 ```
 
-> Para balanceamento sem sticky session, habilite sessoes no Memcached: `APP_MEMCACHED_SESSION=true` (requer SEI 5+).
+> Para balanceamento sem sticky session, habilite sessões no Memcached: `APP_MEMCACHED_SESSION=true` (requer SEI 5+).
 
 ---
 
-## 11. Alterar URL e Dominio
+## 11. Alterar URL e Domínio
 
-### Trocar de localhost para um dominio personalizado
+### Trocar de localhost para um domínio personalizado
 
 1. Pare o projeto:
 ```bash
@@ -438,18 +438,18 @@ make setup
 
 ---
 
-## 12. Instalar Modulos
+## 12. Instalar Módulos
 
-Cada modulo e controlado por variaveis `MODULO_*_INSTALAR` e `MODULO_*_VERSAO` no `envlocal.env`.
+Cada módulo é controlado por variáveis `MODULO_*_INSTALAR` e `MODULO_*_VERSAO` no `envlocal.env`.
 
-### Exemplo: Habilitar modulo de Estatisticas
+### Exemplo: Habilitar módulo de Estatísticas
 
 ```bash
 MODULO_ESTATISTICAS_INSTALAR=true
 MODULO_ESTATISTICAS_VERSAO=master
 ```
 
-### Exemplo: Habilitar modulo PEN (tramitacao entre orgaos)
+### Exemplo: Habilitar módulo PEN (tramitação entre órgãos)
 
 ```bash
 MODULO_PEN_INSTALAR=true
@@ -459,50 +459,50 @@ MODULO_PEN_CERTIFICADO_SENHA=1234
 MODULO_PEN_CERTIFICADO_BASE64=<certificado em base64>
 ```
 
-### Modulos disponiveis
+### Módulos disponíveis
 
-| Modulo | Variavel | Funcao |
+| Módulo | Variável | Função |
 |--------|----------|--------|
-| Estatisticas | `MODULO_ESTATISTICAS_INSTALAR` | Painel de estatisticas |
+| Estatísticas | `MODULO_ESTATISTICAS_INSTALAR` | Painel de estatísticas |
 | REST / WSSEI | `MODULO_REST_INSTALAR` | API REST |
-| Gestao Documental | `MODULO_GESTAODOCUMENTAL_INSTALAR` | Gestao do ciclo de vida |
+| Gestão Documental | `MODULO_GESTAODOCUMENTAL_INSTALAR` | Gestão do ciclo de vida |
 | Resposta | `MODULO_RESPOSTA_INSTALAR` | Respostas a demandas |
-| Login Unico | `MODULO_LOGINUNICO_INSTALAR` | SSO GOV.BR |
+| Login Único | `MODULO_LOGINUNICO_INSTALAR` | SSO GOV.BR |
 | Assinatura | `MODULO_ASSINATURA_INSTALAR` | Assinatura digital ICP-Brasil |
-| PEN | `MODULO_PEN_INSTALAR` | Tramitacao entre orgaos |
-| Peticionamento | `MODULO_PETICIONAMENTO_INSTALAR` | Peticionamento eletronico |
-| Protocolo Integrado | `MODULO_PI_INSTALAR` | Integracao Protocolo.GOV.BR |
-| INCOM | `MODULO_INCOM_INSTALAR` | Publicacao na Imprensa Nacional |
+| PEN | `MODULO_PEN_INSTALAR` | Tramitação entre órgãos |
+| Peticionamento | `MODULO_PETICIONAMENTO_INSTALAR` | Peticionamento eletrônico |
+| Protocolo Integrado | `MODULO_PI_INSTALAR` | Integração Protocolo.GOV.BR |
+| INCOM | `MODULO_INCOM_INSTALAR` | Publicação na Imprensa Nacional |
 
-Para detalhes de cada modulo e suas variaveis, consulte [variaveis-ambiente.md](variaveis-ambiente.md).
+Para detalhes de cada módulo e suas variáveis, consulte [variaveis-ambiente.md](variaveis-ambiente.md).
 
-Apos alterar modulos:
+Após alterar módulos:
 ```bash
 make clear
 make run
 ```
 
-O container `app-atualizador` detecta e instala automaticamente os modulos habilitados.
+O container `app-atualizador` detecta e instala automaticamente os módulos habilitados.
 
 ---
 
-## 13. Usar HTTPS com Certificado Proprio
+## 13. Usar HTTPS com Certificado Próprio
 
-### Certificado auto-assinado (padrao)
+### Certificado auto-assinado (padrão)
 
-Por padrao, o projeto gera certificados auto-assinados automaticamente. Basta:
+Por padrão, o projeto gera certificados auto-assinados automaticamente. Basta:
 ```bash
 APP_PROTOCOLO=https
 ```
 
-### Certificado proprio
+### Certificado próprio
 
-1. Crie o diretorio de certificados definido em `LOCALIZACAO_CERTS`:
+1. Crie o diretório de certificados definido em `LOCALIZACAO_CERTS`:
 ```bash
 mkdir -p ~/sei/certs
 ```
 
-2. Copie seus arquivos de certificado para esse diretorio
+2. Copie seus arquivos de certificado para esse diretório
 
 3. Configure no `envlocal.env`:
 ```bash
@@ -527,14 +527,14 @@ O projeto gera manifests Kubernetes a partir dos templates.
 ```bash
 cd infra
 
-# Ajuste as variaveis KUBERNETES_* no envlocal.env
+# Ajuste as variáveis KUBERNETES_* no envlocal.env
 vi envlocal.env
 
 # Gerar YAML
 make kubernetes_montar_yaml
 ```
 
-Os arquivos sao gerados em `infra/orquestrators/rancher-kubernetes/topublish/`.
+Os arquivos são gerados em `infra/orquestrators/rancher-kubernetes/topublish/`.
 
 ### Aplicar no cluster
 
@@ -548,7 +548,7 @@ make kubernetes_apply
 make kubernetes_delete
 ```
 
-### Configuracao Kubernetes no envlocal.env
+### Configuração Kubernetes no envlocal.env
 
 ```bash
 KUBERNETES_NAMESPACE=seins
@@ -559,18 +559,18 @@ KUBERNETES_LIMITS_CPU_APP=500m
 # ... (ver variaveis-ambiente.md para lista completa)
 ```
 
-> **Nota:** A geracao Kubernetes atualmente funciona apenas para MySQL. O codigo-fonte do SEI deve ser movido manualmente para o PVC `vol-sei-fontes`.
+> **Nota:** A geração Kubernetes atualmente funciona apenas para MySQL. O código-fonte do SEI deve ser movido manualmente para o PVC `vol-sei-fontes`.
 
 ---
 
 ## 15. Build de Imagens Customizadas
 
-Se voce deseja buildar suas proprias imagens ou usar seu proprio registry:
+Se você deseja buildar suas próprias imagens ou usar seu próprio registry:
 
 ```bash
 cd containers
 
-# Criar arquivo de configuracao
+# Criar arquivo de configuração
 make getenv
 
 # Editar envcontainers.env
@@ -589,23 +589,23 @@ make build-conteiner-mysql8-sei50
 make publish-containers
 ```
 
-> Se alterar `DOCKER_REGISTRY` ou `DOCKER_CONTAINER_VERSAO_PRODUTO` nos containers, replique as alteracoes nos envfiles de `dev/` e `infra/`.
+> Se alterar `DOCKER_REGISTRY` ou `DOCKER_CONTAINER_VERSAO_PRODUTO` nos containers, replique as alterações nos envfiles de `dev/` e `infra/`.
 
 ---
 
-## 16. Credenciais Padrao
+## 16. Credenciais Padrão
 
-### Aplicacao SEI/SIP
+### Aplicação SEI/SIP
 
 | Campo | Valor |
 |-------|-------|
-| Usuario | `teste` |
+| Usuário | `teste` |
 | Senha | `teste` |
 
 ### Bancos de Dados
 
 #### MySQL / MariaDB
-| Usuario | Login | Senha |
+| Usuário | Login | Senha |
 |---------|-------|-------|
 | Root | `root` | `P@ssword` |
 | SEI | `sei_user` | `sei_user` |
@@ -614,14 +614,14 @@ make publish-containers
 Acesso: `mysql -h 127.0.0.1 -u root -p sei`
 
 #### PostgreSQL
-| Usuario | Login | Senha |
+| Usuário | Login | Senha |
 |---------|-------|-------|
 | Root | `postgres` | `P@ssword` |
 | SEI | `sei_user` | `sei_user` |
 | SIP | `sip_user` | `sip_user` |
 
 #### Oracle
-| Usuario | Login | Senha |
+| Usuário | Login | Senha |
 |---------|-------|-------|
 | SYS | `sys` | `P@ssword` |
 | System | `system` | `P@ssword` |
@@ -631,7 +631,7 @@ Acesso: `mysql -h 127.0.0.1 -u root -p sei`
 Acesso: `sqlplus sys/P@ssword as sysdba`
 
 #### SQL Server
-| Usuario | Login | Senha |
+| Usuário | Login | Senha |
 |---------|-------|-------|
 | SA | `sa` | `yourStrong(!)Password` |
 | SEI | `sei_user` | `sei_user` |
@@ -644,15 +644,15 @@ Acesso: `tsql -S 127.0.0.1 -U sa -P 'yourStrong(!)Password'`
 |-------|-------|
 | Admin DN | `cn=admin,dc=pen,dc=gov,dc=br` |
 | Senha | `adminldap` |
-| Usuario teste | senha `123456` |
+| Usuário teste | senha `123456` |
 
 ---
 
-## 17. Resolucao de Problemas
+## 17. Resolução de Problemas
 
 ### Portas ocupadas
 
-Antes de subir, verifique se as portas estao livres:
+Antes de subir, verifique se as portas estão livres:
 
 ```bash
 # Infra
@@ -666,25 +666,25 @@ sudo lsof -i :8983  # Solr
 sudo lsof -i :3306  # MySQL
 ```
 
-Se alguma porta estiver ocupada, pare o servico ou altere o mapeamento no `envlocal.env`.
+Se alguma porta estiver ocupada, pare o serviço ou altere o mapeamento no `envlocal.env`.
 
-### SEI nao inicia / tela em branco
+### SEI não inicia / tela em branco
 
 ```bash
 # Verificar se SEI responde
 make check-sei-isalive
 
-# Ver logs da aplicacao
+# Ver logs da aplicação
 make logs_app
 
-# Ver logs do atualizador (instalacao de modulos)
+# Ver logs do atualizador (instalação de módulos)
 make logs_app-atualizador
 
 # Ver todos os logs
 make logs
 ```
 
-### Servicos orfaos apos mudanca de configuracao
+### Serviços órfãos após mudança de configuração
 
 ```bash
 # Sempre rode clear antes de alterar envlocal.env
@@ -693,7 +693,7 @@ make clear
 make run
 ```
 
-### Container do banco nao inicia
+### Container do banco não inicia
 
 ```bash
 # Ver logs do banco
@@ -705,71 +705,71 @@ make criar_volume_banco
 make run
 ```
 
-### Recomecar do zero
+### Recomeçar do zero
 
 ```bash
 cd infra
 make clear
 make apagar_volumes
-# Edite envlocal.env se necessario
+# Edite envlocal.env se necessário
 make setup
 ```
 
-### Versao incompativel
+### Versão incompatível
 
 ```bash
 # Verificar compatibilidade
 make check-version-compatibility
 ```
 
-O projeto valida se a versao do codigo-fonte e compativel com as imagens Docker.
+O projeto valida se a versão do código-fonte é compatível com as imagens Docker.
 
 ### Docker Compose v1 vs v2
 
 O projeto detecta automaticamente. Se tiver problemas:
 ```bash
-# Verificar qual esta instalado
+# Verificar qual está instalado
 docker compose version    # v2
 docker-compose --version  # v1
 ```
 
 ---
 
-## 18. Video Tutoriais
+## 18. Vídeo Tutoriais
 
-Videos gravados pela equipe do projeto com orientacoes praticas:
+Vídeos gravados pela equipe do projeto com orientações práticas:
 
-| Video | Conteudo | Link |
+| Vídeo | Conteúdo | Link |
 |-------|----------|------|
-| Infra Reduzida Rapidamente | Subida basica em localhost com HTTPS | [Assistir](https://www.youtube.com/watch?v=FwPp9lZiHuM) |
+| Infra Reduzida Rapidamente | Subida básica em localhost com HTTPS | [Assistir](https://www.youtube.com/watch?v=FwPp9lZiHuM) |
 | Infra Completa Rapidamente | Todos os componentes, domain name, HTTPS | [Assistir](https://www.youtube.com/watch?v=MpTLtDlSVLw) |
 | SqlServer ou Oracle | Como usar bancos alternativos | [Assistir](https://www.youtube.com/watch?v=IgEiR5CZEEs) |
-| Organizacao do Projeto | Estrutura tecnica e anatomia da solucao | [Assistir](https://www.youtube.com/watch?v=rczbANlWVRY) |
-| Customizacoes Basicas | Trocar hostname, Solr admin, scale | [Assistir](https://www.youtube.com/watch?v=HjZfryu0sco) |
-| Customizacoes Completas | Todos os componentes, LDAP, orientacoes avancadas | [Assistir](https://www.youtube.com/watch?v=m5wXBPDMVQQ) |
+| Organização do Projeto | Estrutura técnica e anatomia da solução | [Assistir](https://www.youtube.com/watch?v=rczbANlWVRY) |
+| Customizações Básicas | Trocar hostname, Solr admin, scale | [Assistir](https://www.youtube.com/watch?v=HjZfryu0sco) |
+| Customizações Completas | Todos os componentes, LDAP, orientações avançadas | [Assistir](https://www.youtube.com/watch?v=m5wXBPDMVQQ) |
 
 > Recomendado assistir na ordem listada acima.
 
 ---
 
-## 19. Dicas e Boas Praticas
+## 19. Dicas e Boas Práticas
 
-1. **Comece simples.** Suba com as configuracoes padrao primeiro. Teste. Depois va customizando um parametro por vez.
+1. **Comece simples.** Suba com as configurações padrão primeiro. Teste. Depois vá customizando um parâmetro por vez.
 
-2. **Sempre `make clear` antes de alterar.** Evita servicos orfaos e conflitos.
+2. **Sempre `make clear` antes de alterar.** Evita serviços órfãos e conflitos.
 
-3. **Nao altere o envlocal.env inteiro de uma vez.** Altere um parametro, suba, teste, repita.
+3. **Não altere o envlocal.env inteiro de uma vez.** Altere um parâmetro, suba, teste, repita.
 
-4. **Volumes sao seus dados.** `make apagar_volumes` apaga banco de dados, arquivos anexados, indices Solr. Use com cuidado.
+4. **Volumes são seus dados.** `make apagar_volumes` apaga banco de dados, arquivos anexados, índices Solr. Use com cuidado.
 
-5. **`make clear` e seguro.** Remove apenas containers e redes, nunca dados.
+5. **`make clear` é seguro.** Remove apenas containers e redes, nunca dados.
 
 6. **Verifique portas antes de subir.** Portas 80 e 443 (infra) ou 8000 (dev) devem estar livres.
 
-7. **Use `make help`.** Todos os Makefiles possuem ajuda embutida com descricao de cada comando.
+7. **Use `make help`.** Todos os Makefiles possuem ajuda embutida com descrição de cada comando.
 
-8. **DNS ou /etc/hosts.** Ao usar um dominio customizado, garanta que o DNS ou `/etc/hosts` aponte para a maquina correta.
+8. **DNS ou /etc/hosts.** Ao usar um domínio customizado, garanta que o DNS ou `/etc/hosts` aponte para a máquina correta.
 
-9. **Backup dos volumes.** Em ambiente de teste/treinamento, faca backup do volume do banco (`VOLUME_DB`) e dos arquivos externos (`VOLUME_ARQUIVOSEXTERNOS`).
+9. **Backup dos volumes.** Em ambiente de teste/treinamento, faça backup do volume do banco (`VOLUME_DB`) e dos arquivos externos (`VOLUME_ARQUIVOSEXTERNOS`).
 
-10. **Nao e para producao.** O projeto e para DTH. Producao requer hardening de seguranca, firewall, backup e configuracoes adicionais conforme documentacao do TRF e PEN.
+10. **Não é para produção.** O projeto é para DTH. Produção requer hardening de segurança, firewall, backup e configurações adicionais conforme documentação do TRF e PEN.

--- a/docs/orquestracao.md
+++ b/docs/orquestracao.md
@@ -1,6 +1,6 @@
-# Orquestracao e Deploy
+# Orquestração e Deploy
 
-Guia tecnico sobre as opcoes de deploy, automacao via Makefiles e orquestracao com Docker Compose e Kubernetes.
+Guia técnico sobre as opções de deploy, automação via Makefiles e orquestração com Docker Compose e Kubernetes.
 
 ---
 
@@ -16,21 +16,21 @@ Guia tecnico sobre as opcoes de deploy, automacao via Makefiles e orquestracao c
 
 ## Docker Compose (Infraestrutura)
 
-### Geracao Dinamica do docker-compose.yml
+### Geração Dinâmica do docker-compose.yml
 
-O arquivo `docker-compose.yml` e gerado dinamicamente a partir de um template. O processo utiliza `envsubst` para substituir variaveis e `sed` para habilitar/desabilitar servicos opcionais.
+O arquivo `docker-compose.yml` é gerado dinamicamente a partir de um template. O processo utiliza `envsubst` para substituir variáveis e `sed` para habilitar/desabilitar serviços opcionais.
 
 **Template:** `infra/orquestrators/docker-compose/docker-compose-template.yml`
 
-**Fluxo de geracao:**
+**Fluxo de geração:**
 
 ```
 envlocal.env  ──→  envsubst  ──→  sed (toggles)  ──→  docker-compose.yml
 ```
 
-**Toggles de servicos (via `sed`):**
+**Toggles de serviços (via `sed`):**
 
-| Tag no Template | Variavel de Controle | Servico |
+| Tag no Template | Variável de Controle | Serviço |
 |-----------------|---------------------|---------|
 | `#serviceldap` | `OPENLDAP_PRESENTE` | OpenLDAP + phpLDAPadmin |
 | `#servicejod` | `JOD_PRESENTE` | JOD Converter |
@@ -40,24 +40,24 @@ envlocal.env  ──→  envsubst  ──→  sed (toggles)  ──→  docker-c
 | `#servicebal` | `BALANCEADOR_PRESENTE` | Traefik |
 | `#app-traefik` | `BALANCEADOR_PRESENTE` | Labels Traefik no app |
 
-Quando a variavel e `true`, o `sed` remove o `#tag` do inicio das linhas correspondentes, ativando o servico.
+Quando a variável é `true`, o `sed` remove o `#tag` do início das linhas correspondentes, ativando o serviço.
 
-### Servicos Ativos (padrao)
+### Serviços Ativos (padrão)
 
-| Servico | Imagem | Funcao |
+| Serviço | Imagem | Função |
 |---------|--------|--------|
 | `storage-app` | `busybox:latest` | Sidecar para volumes |
 | `storage-certs` | `busybox:latest` | Sidecar para certificados |
 | `memcached` | `${DOCKER_IMAGE_MEMCACHED}` | Cache |
 | `db` | `${DOCKER_IMAGE_BD}` | Banco de dados |
 | `solr` | `${DOCKER_IMAGE_SOLR}` | Busca full-text |
-| `app-atualizador` | `${DOCKER_IMAGE_APP}` | Instalacao/atualizacao |
+| `app-atualizador` | `${DOCKER_IMAGE_APP}` | Instalação/atualização |
 | `app-agendador` | `${DOCKER_IMAGE_APP_AGENDADOR}` | Jobs em background |
-| `app` | `${DOCKER_IMAGE_APP}` | Aplicacao web |
+| `app` | `${DOCKER_IMAGE_APP}` | Aplicação web |
 
-### Servicos Opcionais
+### Serviços Opcionais
 
-| Servico | Toggle | URL de Acesso |
+| Serviço | Toggle | URL de Acesso |
 |---------|--------|---------------|
 | `balanceador` | `BALANCEADOR_PRESENTE=true` | `:80` / `:443` |
 | `jod` | `JOD_PRESENTE=true` | interno |
@@ -75,19 +75,19 @@ Quando a variavel e `true`, o `sed` remove o `#tag` do inicio das linhas corresp
 ### Comandos Principais
 
 ```bash
-# Ver todos os comandos disponiveis
+# Ver todos os comandos disponíveis
 make help
 
-# Setup completo (cria volumes + sobe servicos)
+# Setup completo (cria volumes + sobe serviços)
 make setup
 
 # Apenas construir docker-compose.yml
 make build_docker_compose
 
-# Subir servicos (build + up -d)
+# Subir serviços (build + up -d)
 make run
 
-# Escalar aplicacao (padrao 2 nos)
+# Escalar aplicação (padrão 2 nós)
 make scale
 make scale qtd=3
 
@@ -125,8 +125,8 @@ make apagar_volume_solr
 ### Logs
 
 ```bash
-make logs                  # Todos os servicos
-make logs_app              # Aplicacao
+make logs                  # Todos os serviços
+make logs_app              # Aplicação
 make logs_app-atualizador  # Atualizador
 make logs_balanceador      # Traefik
 make logs_openldap         # OpenLDAP
@@ -139,10 +139,10 @@ make logs_solr             # Solr
 # Verifica se SEI responde com tela de login
 make check-sei-isalive
 
-# Verifica compatibilidade de versao fonte vs containers
+# Verifica compatibilidade de versão fonte vs containers
 make check-version-compatibility
 
-# Verifica se fontes estao posicionados
+# Verifica se fontes estão posicionados
 make check-fontes-posicionado
 ```
 
@@ -150,13 +150,13 @@ make check-fontes-posicionado
 
 ## Kubernetes
 
-### Geracao de Manifests
+### Geração de Manifests
 
-Os manifests Kubernetes sao gerados a partir de templates usando `envsubst`, similar ao docker-compose.
+Os manifests Kubernetes são gerados a partir de templates usando `envsubst`, similar ao docker-compose.
 
 **Templates:** `infra/orquestrators/rancher-kubernetes/templates/`
 
-| Template | Conteudo |
+| Template | Conteúdo |
 |----------|----------|
 | `deploys-svc-template.yaml` | Deployments e Services |
 | `statefullsets-template.yaml` | StatefulSets |
@@ -166,7 +166,7 @@ Os manifests Kubernetes sao gerados a partir de templates usando `envsubst`, sim
 | `jobs-template.yaml` | Jobs (one-time) |
 | `ingress-template.yaml` | Ingress rules |
 
-**Saida:** `infra/orquestrators/rancher-kubernetes/topublish/*.yaml`
+**Saída:** `infra/orquestrators/rancher-kubernetes/topublish/*.yaml`
 
 ### Comandos Kubernetes
 
@@ -180,17 +180,17 @@ make kubernetes_apply
 # Remover do cluster
 make kubernetes_delete
 
-# Verificar deploy especifico
+# Verificar deploy específico
 make kubernetes_check_deploy_generic KUBE_DEPLOY_NAME=app
 ```
 
-### Configuracao Kubernetes
+### Configuração Kubernetes
 
-As variaveis `KUBERNETES_*` controlam:
+As variáveis `KUBERNETES_*` controlam:
 - **Namespace:** `KUBERNETES_NAMESPACE=seins`
 - **Storage class:** `KUBERNETES_PVC_STORAGECLASS=nfs-client`
-- **Recursos:** Limites e requests de CPU/memoria por servico
-- **Timeout:** 180s para verificacao de deploy
+- **Recursos:** Limites e requests de CPU/memória por serviço
+- **Timeout:** 180s para verificação de deploy
 
 ---
 
@@ -203,7 +203,7 @@ As variaveis `KUBERNETES_*` controlam:
 ```bash
 cd containers
 
-# Copiar template de configuracao
+# Copiar template de configuração
 make getenv
 
 # Editar envcontainers.env
@@ -213,7 +213,7 @@ vi envcontainers.env
 ### Build de Imagens
 
 ```bash
-# Build de TODAS as imagens (ordem correta de dependencias)
+# Build de TODAS as imagens (ordem correta de dependências)
 make build-conteiners
 
 # Build individual (exemplos)
@@ -225,14 +225,14 @@ make build-conteiner-mysql8-sei50
 make build-conteiner-solr-9.6.1
 make build-conteiner-traefik
 
-# Build generico (parametrizado)
+# Build genérico (parametrizado)
 make build-conteiner-generic \
   IMAGEMTMP=minha-imagem \
   IMAGEMTMP_VERSAO=1.0.0 \
   IMAGEMTMP_PATH=caminho/do/dockerfile
 ```
 
-### Publicacao no Registry
+### Publicação no Registry
 
 ```bash
 # Publicar todas as imagens
@@ -243,7 +243,7 @@ make publish-container-app-ci-php8
 make publish-container-mysql8-sei50
 ```
 
-Cada publicacao envia a tag versionada e `:latest` (exceto quando versao e "test").
+Cada publicação envia a tag versionada e `:latest` (exceto quando versão é "test").
 
 ### Limpeza
 
@@ -258,7 +258,7 @@ make erase-conteiner-mysql8-sei50
 
 ---
 
-## Ordem de Build (Dependencias)
+## Ordem de Build (Dependências)
 
 A ordem correta de build respeita a hierarquia de imagens:
 
@@ -267,7 +267,7 @@ A ordem correta de build respeita a hierarquia de imagens:
    ├── base-centos7
    └── base-rocky93
 
-2. Imagens base de servico
+2. Imagens base de serviço
    ├── base-mariadb10.5
    ├── base-mysql8
    ├── base-sqlserver2019
@@ -286,7 +286,7 @@ A ordem correta de build respeita a hierarquia de imagens:
    ├── oracle11g-sei40/41/50 (depende de base-oracle11g)
    └── postgres15-sei40/41/50 (depende de base-postgres15)
 
-4. Imagens da aplicacao
+4. Imagens da aplicação
    ├── app-ci (depende de base-app)
    ├── app-ci-php8 (depende de base-app-php8)
    ├── app-dev (depende de base-app)
@@ -296,26 +296,26 @@ A ordem correta de build respeita a hierarquia de imagens:
    ├── app-ci-agendador (depende de app-ci)
    └── app-ci-php8-agendador (depende de app-ci-php8)
 
-6. Demais servicos
+6. Demais serviços
    ├── solr8.2.0 (depende de base-centos7)
    ├── solr9.4.0, solr9.6.1 (depende de base-rocky93)
    ├── jod (depende de base-centos7)
-   ├── jod4.4.8 (alpine, sem dependencia)
+   ├── jod4.4.8 (alpine, sem dependência)
    ├── traefik (depende de traefik-base)
    ├── openldap (depende de openldap-base)
-   ├── memcached (sem dependencia)
-   └── mailcatcher (sem dependencia)
+   ├── memcached (sem dependência)
+   └── mailcatcher (sem dependência)
 ```
 
 ---
 
 ## Modalidades de Deploy (Infra)
 
-| Modalidade | Balanceador | HTTPS | Servicos Opcionais | Uso |
+| Modalidade | Balanceador | HTTPS | Serviços Opcionais | Uso |
 |------------|-------------|-------|---------------------|-----|
-| **Reduzida** | Nao | Sim | Nenhum | Teste minimo |
-| **Default** | Sim | Sim | JOD | Teste padrao |
+| **Reduzida** | Não | Sim | Nenhum | Teste mínimo |
+| **Default** | Sim | Sim | JOD | Teste padrão |
 | **Completa** | Sim | Sim | Todos (LDAP, Mail, DB Admin, etc) | Teste completo |
-| **HTTP** | Variavel | Nao | Variavel | Sem TLS |
+| **HTTP** | Variável | Não | Variável | Sem TLS |
 
-Configuracao via variaveis booleanas `*_PRESENTE` no `envlocal.env`.
+Configuração via variáveis booleanas `*_PRESENTE` no `envlocal.env`.

--- a/docs/orquestracao.md
+++ b/docs/orquestracao.md
@@ -1,0 +1,321 @@
+# Orquestracao e Deploy
+
+Guia tecnico sobre as opcoes de deploy, automacao via Makefiles e orquestracao com Docker Compose e Kubernetes.
+
+---
+
+## Plataformas Suportadas
+
+| Plataforma | Status | Caminho |
+|------------|--------|---------|
+| **Docker Compose** | Ativo (principal) | `infra/orquestrators/docker-compose/` |
+| **Kubernetes** | Ativo | `infra/orquestrators/rancher-kubernetes/` |
+| **Rancher Cattle** | Legado | `infra/orquestrators/rancher-cattle/` |
+
+---
+
+## Docker Compose (Infraestrutura)
+
+### Geracao Dinamica do docker-compose.yml
+
+O arquivo `docker-compose.yml` e gerado dinamicamente a partir de um template. O processo utiliza `envsubst` para substituir variaveis e `sed` para habilitar/desabilitar servicos opcionais.
+
+**Template:** `infra/orquestrators/docker-compose/docker-compose-template.yml`
+
+**Fluxo de geracao:**
+
+```
+envlocal.env  ──→  envsubst  ──→  sed (toggles)  ──→  docker-compose.yml
+```
+
+**Toggles de servicos (via `sed`):**
+
+| Tag no Template | Variavel de Controle | Servico |
+|-----------------|---------------------|---------|
+| `#serviceldap` | `OPENLDAP_PRESENTE` | OpenLDAP + phpLDAPadmin |
+| `#servicejod` | `JOD_PRESENTE` | JOD Converter |
+| `#servicemail` | `MAIL_CATCHER_PRESENTE` | MailCatcher |
+| `#servicememcachedadmin` | `MEMCACHEDADMIN_PRESENTE` | phpMemcachedAdmin |
+| `#servicedbadmin` | `DBADMIN_PRESENTE` | Adminer |
+| `#servicebal` | `BALANCEADOR_PRESENTE` | Traefik |
+| `#app-traefik` | `BALANCEADOR_PRESENTE` | Labels Traefik no app |
+
+Quando a variavel e `true`, o `sed` remove o `#tag` do inicio das linhas correspondentes, ativando o servico.
+
+### Servicos Ativos (padrao)
+
+| Servico | Imagem | Funcao |
+|---------|--------|--------|
+| `storage-app` | `busybox:latest` | Sidecar para volumes |
+| `storage-certs` | `busybox:latest` | Sidecar para certificados |
+| `memcached` | `${DOCKER_IMAGE_MEMCACHED}` | Cache |
+| `db` | `${DOCKER_IMAGE_BD}` | Banco de dados |
+| `solr` | `${DOCKER_IMAGE_SOLR}` | Busca full-text |
+| `app-atualizador` | `${DOCKER_IMAGE_APP}` | Instalacao/atualizacao |
+| `app-agendador` | `${DOCKER_IMAGE_APP_AGENDADOR}` | Jobs em background |
+| `app` | `${DOCKER_IMAGE_APP}` | Aplicacao web |
+
+### Servicos Opcionais
+
+| Servico | Toggle | URL de Acesso |
+|---------|--------|---------------|
+| `balanceador` | `BALANCEADOR_PRESENTE=true` | `:80` / `:443` |
+| `jod` | `JOD_PRESENTE=true` | interno |
+| `openldap` + `ldapadmin` | `OPENLDAP_PRESENTE=true` | `/phpldapadmin` |
+| `mail` | `MAIL_CATCHER_PRESENTE=true` | `/mailadmin` |
+| `memcachedadmin` | `MEMCACHEDADMIN_PRESENTE=true` | `/memcachedadmin` |
+| `dbadmin` | `DBADMIN_PRESENTE=true` | `/dbadmin` |
+
+---
+
+## Makefile de Infraestrutura
+
+**Arquivo:** `infra/Makefile`
+
+### Comandos Principais
+
+```bash
+# Ver todos os comandos disponiveis
+make help
+
+# Setup completo (cria volumes + sobe servicos)
+make setup
+
+# Apenas construir docker-compose.yml
+make build_docker_compose
+
+# Subir servicos (build + up -d)
+make run
+
+# Escalar aplicacao (padrao 2 nos)
+make scale
+make scale qtd=3
+
+# Parar e remover containers
+make stop
+
+# Parar sem remover volumes
+make clear
+
+# Apagar TUDO (volumes inclusos - DESTRUTIVO)
+make apagar_volumes
+```
+
+### Gerenciamento de Volumes
+
+```bash
+# Criar todos os volumes
+make criar_volumes
+
+# Criar volumes individuais
+make criar_volume_fontes
+make criar_volume_certs
+make criar_volume_banco
+make criar_volume_arquivos_externos
+make criar_volume_solr
+make criar_volume_openldap
+make criar_volume_controlador_instalacao
+
+# Apagar volumes individuais
+make apagar_volume_fontes
+make apagar_volume_banco
+make apagar_volume_solr
+```
+
+### Logs
+
+```bash
+make logs                  # Todos os servicos
+make logs_app              # Aplicacao
+make logs_app-atualizador  # Atualizador
+make logs_balanceador      # Traefik
+make logs_openldap         # OpenLDAP
+make logs_solr             # Solr
+```
+
+### Health Checks
+
+```bash
+# Verifica se SEI responde com tela de login
+make check-sei-isalive
+
+# Verifica compatibilidade de versao fonte vs containers
+make check-version-compatibility
+
+# Verifica se fontes estao posicionados
+make check-fontes-posicionado
+```
+
+---
+
+## Kubernetes
+
+### Geracao de Manifests
+
+Os manifests Kubernetes sao gerados a partir de templates usando `envsubst`, similar ao docker-compose.
+
+**Templates:** `infra/orquestrators/rancher-kubernetes/templates/`
+
+| Template | Conteudo |
+|----------|----------|
+| `deploys-svc-template.yaml` | Deployments e Services |
+| `statefullsets-template.yaml` | StatefulSets |
+| `configmaps-template.yaml` | ConfigMaps |
+| `secrets-template.yaml` | Secrets (credenciais, certificados) |
+| `pvc-template.yaml` | PersistentVolumeClaims |
+| `jobs-template.yaml` | Jobs (one-time) |
+| `ingress-template.yaml` | Ingress rules |
+
+**Saida:** `infra/orquestrators/rancher-kubernetes/topublish/*.yaml`
+
+### Comandos Kubernetes
+
+```bash
+# Gerar manifests a partir dos templates
+make kubernetes_montar_yaml
+
+# Aplicar no cluster
+make kubernetes_apply
+
+# Remover do cluster
+make kubernetes_delete
+
+# Verificar deploy especifico
+make kubernetes_check_deploy_generic KUBE_DEPLOY_NAME=app
+```
+
+### Configuracao Kubernetes
+
+As variaveis `KUBERNETES_*` controlam:
+- **Namespace:** `KUBERNETES_NAMESPACE=seins`
+- **Storage class:** `KUBERNETES_PVC_STORAGECLASS=nfs-client`
+- **Recursos:** Limites e requests de CPU/memoria por servico
+- **Timeout:** 180s para verificacao de deploy
+
+---
+
+## Makefile de Containers (Build)
+
+**Arquivo:** `containers/Makefile`
+
+### Setup Inicial
+
+```bash
+cd containers
+
+# Copiar template de configuracao
+make getenv
+
+# Editar envcontainers.env
+vi envcontainers.env
+```
+
+### Build de Imagens
+
+```bash
+# Build de TODAS as imagens (ordem correta de dependencias)
+make build-conteiners
+
+# Build individual (exemplos)
+make build-conteiner-base-rocky93
+make build-conteiner-base-app-php8
+make build-conteiner-app-ci-php8
+make build-conteiner-app-ci-php8-agendador
+make build-conteiner-mysql8-sei50
+make build-conteiner-solr-9.6.1
+make build-conteiner-traefik
+
+# Build generico (parametrizado)
+make build-conteiner-generic \
+  IMAGEMTMP=minha-imagem \
+  IMAGEMTMP_VERSAO=1.0.0 \
+  IMAGEMTMP_PATH=caminho/do/dockerfile
+```
+
+### Publicacao no Registry
+
+```bash
+# Publicar todas as imagens
+make publish-containers
+
+# Publicar individual
+make publish-container-app-ci-php8
+make publish-container-mysql8-sei50
+```
+
+Cada publicacao envia a tag versionada e `:latest` (exceto quando versao e "test").
+
+### Limpeza
+
+```bash
+# Apagar TODAS as imagens locais
+make erase-conteiners-local
+
+# Apagar individual
+make erase-conteiner-app-ci-php8
+make erase-conteiner-mysql8-sei50
+```
+
+---
+
+## Ordem de Build (Dependencias)
+
+A ordem correta de build respeita a hierarquia de imagens:
+
+```
+1. Imagens base do SO
+   ├── base-centos7
+   └── base-rocky93
+
+2. Imagens base de servico
+   ├── base-mariadb10.5
+   ├── base-mysql8
+   ├── base-sqlserver2019
+   ├── base-oracle11g
+   ├── base-postgres15
+   ├── base-app (depende de base-centos7)
+   ├── base-app-php8 (depende de base-rocky93)
+   ├── traefik-base
+   ├── haproxy-base
+   └── openldap-base
+
+3. Imagens de banco com schema
+   ├── mariadb10.5-sei40/41/50 (depende de base-mariadb10.5)
+   ├── mysql8-sei41/50 (depende de base-mysql8)
+   ├── sqlserver2019-sei40/41/50 (depende de base-sqlserver2019)
+   ├── oracle11g-sei40/41/50 (depende de base-oracle11g)
+   └── postgres15-sei40/41/50 (depende de base-postgres15)
+
+4. Imagens da aplicacao
+   ├── app-ci (depende de base-app)
+   ├── app-ci-php8 (depende de base-app-php8)
+   ├── app-dev (depende de base-app)
+   └── app-dev-php8 (depende de base-app-php8)
+
+5. Imagens do agendador
+   ├── app-ci-agendador (depende de app-ci)
+   └── app-ci-php8-agendador (depende de app-ci-php8)
+
+6. Demais servicos
+   ├── solr8.2.0 (depende de base-centos7)
+   ├── solr9.4.0, solr9.6.1 (depende de base-rocky93)
+   ├── jod (depende de base-centos7)
+   ├── jod4.4.8 (alpine, sem dependencia)
+   ├── traefik (depende de traefik-base)
+   ├── openldap (depende de openldap-base)
+   ├── memcached (sem dependencia)
+   └── mailcatcher (sem dependencia)
+```
+
+---
+
+## Modalidades de Deploy (Infra)
+
+| Modalidade | Balanceador | HTTPS | Servicos Opcionais | Uso |
+|------------|-------------|-------|---------------------|-----|
+| **Reduzida** | Nao | Sim | Nenhum | Teste minimo |
+| **Default** | Sim | Sim | JOD | Teste padrao |
+| **Completa** | Sim | Sim | Todos (LDAP, Mail, DB Admin, etc) | Teste completo |
+| **HTTP** | Variavel | Nao | Variavel | Sem TLS |
+
+Configuracao via variaveis booleanas `*_PRESENTE` no `envlocal.env`.

--- a/docs/testes.md
+++ b/docs/testes.md
@@ -1,0 +1,219 @@
+# Testes - Infraestrutura de Testes
+
+Documentacao tecnica sobre as suites de teste do projeto SEI-Docker.
+
+---
+
+## Visao Geral
+
+O projeto possui **3 niveis de teste**, cada um com escopo e objetivos diferentes:
+
+| Nivel | Caminho | Escopo |
+|-------|---------|--------|
+| **Containers** | `containers/tests/` | Valida build, push e pull de todas as 44 imagens |
+| **Infraestrutura** | `infra/tests/` | Testa deploy completo em 16 combinacoes (4 modalidades x 4 bancos) |
+| **Desenvolvimento** | `dev/tests/` | Testes funcionais com Selenium no ambiente dev |
+
+---
+
+## 1. Testes de Containers
+
+**Caminho:** `containers/tests/`
+**Comando:** `make test-containers`
+
+### O que testa
+
+Para cada uma das 44 imagens Docker:
+
+1. **Erase** - Apaga imagem local (se existir)
+2. **Build** - Reconstroi a imagem
+3. **Push** - Publica no registry
+4. **Re-erase** - Apaga a imagem local novamente
+5. **Pull** - Baixa do registry
+6. **Final erase** - Limpeza final
+
+### Imagens testadas
+
+**Bases:** base-centos7, base-rocky93
+
+**Bancos:** base-mariadb10.5, base-mysql8, base-sqlserver2019, base-oracle11g, base-postgres15, mariadb10.5-sei40/41/50, mysql8-sei41/50, sqlserver2019-sei40/41/50, oracle11g-sei40/41/50, postgres15-sei40/41/50
+
+**Aplicacao:** base-app, base-app-php8, app-dev, app-dev-php8, app-ci, app-ci-php8, app-ci-agendador, app-ci-php8-agendador
+
+**Servicos:** memcached, jod, jod4.4.8, solr8.2.0, solr9.4.0, solr9.6.1, traefik-base, traefik, haproxy-base, haproxy, openldap-base, openldap, phpmemcachedadmin-base, phpmemcachedadmin, phpldapadmin, dbadminer, mailcatcher
+
+---
+
+## 2. Testes de Infraestrutura
+
+**Caminho:** `infra/tests/`
+**Makefile:** `infra/tests/Makefile`
+
+### Matriz de Testes
+
+Os testes combinam **modalidades de deploy** com **bancos de dados**:
+
+| | MySQL | SQL Server | Oracle | PostgreSQL |
+|---|---|---|---|---|
+| **Reduzida** | X | X | X | X |
+| **Default** | X | X | X | X |
+| **Completa** | X | X | X | X |
+| **HTTP** | X | X | X | X |
+
+**Total:** 16 combinacoes
+
+### Modalidades
+
+| Modalidade | Descricao |
+|------------|-----------|
+| **Reduzida** | Sem load balancer, URL customizada, HTTPS |
+| **Default** | Com load balancer, localhost |
+| **Completa** | Todos os servicos opcionais habilitados, HTTPS |
+| **HTTP** | Variantes HTTP (sem TLS) |
+
+### Comandos
+
+```bash
+cd infra/tests
+
+# Rodar suite completa (todas as 16 combinacoes)
+make test_lineup_completa
+
+# Rodar por modalidade
+make test_ambientes_reduzida
+make test_ambientes_default
+make test_ambientes_completa
+make test_ambientes_full
+
+# Rodar combinacao especifica
+make MODALIDADE=completa BANCO=oracle test_ambiente
+make MODALIDADE=default BANCO=mysql test_ambiente
+make MODALIDADE=reduzida BANCO=postgres test_ambiente
+```
+
+### Arquivos de Configuracao de Teste
+
+| Arquivo | Modalidade |
+|---------|------------|
+| `test-envlocal-reduzida.env` | Deploy reduzido |
+| `test-envlocal-http.env` | Deploy HTTP |
+| `test-envlocal-completa.env` | Deploy completo |
+| (padrao do infra) | Deploy default |
+
+### Validacoes Executadas
+
+Para cada combinacao, o teste executa:
+
+1. **Criacao de volumes** - Verifica se todos os volumes foram criados
+2. **Deploy dos servicos** - `make setup` ou `make run`
+3. **Health check do SEI** - Acessa tela de login via `curl`
+4. **Verificacao do balanceador** - Testa dashboard Traefik (se presente)
+5. **Verificacao de componentes** - JOD, admin UIs (se presentes)
+6. **Escalonamento** - Escala app de 1 -> 2 -> 3 -> 1 instancias
+7. **Testes Selenium** - Workflow funcional completo
+8. **Limpeza** - `make clear && make apagar_volumes`
+
+---
+
+## 3. Testes Selenium
+
+**Caminho:** `infra/tests/Selenium/PythonExported/`
+**Arquivo principal:** `test_suiteBasics.py`
+
+### Workflow Testado
+
+O teste Selenium simula um usuario completo:
+
+1. **Login** - Acessa SEI e faz login com credenciais
+2. **Validacao de modulos** - Verifica se modulos instalados estao disponiveis
+3. **Criacao de processo** - Cria um novo processo eletronico
+4. **Documento com anexo** - Cria documento e anexa arquivo
+5. **Documento interno** - Cria documento interno no processo
+6. **Logout** - Realiza logout e verifica redirecionamento
+
+### Infraestrutura Selenium
+
+- **Driver:** Chrome headless via Docker (`selenium/standalone-chrome`)
+- **Rede:** Docker network ou host networking
+- **Tentativas:** Ate 3 retentativas por teste
+- **Relatorio:** XML JUnit (`resultado.xml`)
+
+### Execucao Manual
+
+```bash
+cd infra/tests
+
+# Via Docker (recomendado)
+docker run --rm \
+  --network=host \
+  -v $(pwd)/Selenium:/tests \
+  selenium/standalone-chrome \
+  python3 /tests/PythonExported/test_suiteBasics.py
+
+# Variaveis de ambiente para o teste
+export SEI_URL="https://localhost/sei"
+export SEI_USUARIO="teste"
+export SEI_SENHA="teste"
+```
+
+---
+
+## 4. Testes de Desenvolvimento
+
+**Caminho:** `dev/tests/`
+**Comando:** `make tests-all-bases`
+
+### O que testa
+
+Executa testes funcionais Selenium em todas as combinacoes de banco de dados no ambiente de desenvolvimento.
+
+### Restricoes
+
+- Funciona apenas em **Linux** (usa Docker host networking)
+- Requer `localhost` como URL do SEI
+- Codigo-fonte deve estar disponivel em `SEI_PATH`
+
+---
+
+## Deteccao de Docker Compose
+
+Todos os Makefiles detectam automaticamente a versao do Docker Compose:
+
+```makefile
+# Detecta "docker compose" (v2) ou "docker-compose" (v1)
+DC := $(shell docker compose version 2>/dev/null && echo "docker compose" || echo "docker-compose")
+```
+
+---
+
+## CI/CD
+
+### Jenkins
+
+**Caminho:** `infra/jenkins/`
+**Status:** Placeholder (`comminganytime.txt`)
+
+A integracao com Jenkins e prevista mas nao implementada. Atualmente o CI/CD e feito via Makefiles.
+
+### Pipeline de CI Recomendado
+
+```
+1. Build de imagens base
+   make build-conteiner-base-centos
+   make build-conteiner-base-rocky93
+
+2. Build de imagens de servico
+   make build-conteiners
+
+3. Teste de containers
+   cd containers/tests && make test-containers
+
+4. Deploy de teste
+   cd infra && make setup
+
+5. Testes de integracao
+   cd infra/tests && make test_lineup_completa
+
+6. Publicacao
+   cd containers && make publish-containers
+```

--- a/docs/testes.md
+++ b/docs/testes.md
@@ -1,17 +1,17 @@
 # Testes - Infraestrutura de Testes
 
-Documentacao tecnica sobre as suites de teste do projeto SEI-Docker.
+Documentação técnica sobre as suítes de teste do projeto SEI-Docker.
 
 ---
 
-## Visao Geral
+## Visão Geral
 
-O projeto possui **3 niveis de teste**, cada um com escopo e objetivos diferentes:
+O projeto possui **3 níveis de teste**, cada um com escopo e objetivos diferentes:
 
-| Nivel | Caminho | Escopo |
+| Nível | Caminho | Escopo |
 |-------|---------|--------|
 | **Containers** | `containers/tests/` | Valida build, push e pull de todas as 44 imagens |
-| **Infraestrutura** | `infra/tests/` | Testa deploy completo em 16 combinacoes (4 modalidades x 4 bancos) |
+| **Infraestrutura** | `infra/tests/` | Testa deploy completo em 16 combinações (4 modalidades x 4 bancos) |
 | **Desenvolvimento** | `dev/tests/` | Testes funcionais com Selenium no ambiente dev |
 
 ---
@@ -26,7 +26,7 @@ O projeto possui **3 niveis de teste**, cada um com escopo e objetivos diferente
 Para cada uma das 44 imagens Docker:
 
 1. **Erase** - Apaga imagem local (se existir)
-2. **Build** - Reconstroi a imagem
+2. **Build** - Reconstrói a imagem
 3. **Push** - Publica no registry
 4. **Re-erase** - Apaga a imagem local novamente
 5. **Pull** - Baixa do registry
@@ -38,9 +38,9 @@ Para cada uma das 44 imagens Docker:
 
 **Bancos:** base-mariadb10.5, base-mysql8, base-sqlserver2019, base-oracle11g, base-postgres15, mariadb10.5-sei40/41/50, mysql8-sei41/50, sqlserver2019-sei40/41/50, oracle11g-sei40/41/50, postgres15-sei40/41/50
 
-**Aplicacao:** base-app, base-app-php8, app-dev, app-dev-php8, app-ci, app-ci-php8, app-ci-agendador, app-ci-php8-agendador
+**Aplicação:** base-app, base-app-php8, app-dev, app-dev-php8, app-ci, app-ci-php8, app-ci-agendador, app-ci-php8-agendador
 
-**Servicos:** memcached, jod, jod4.4.8, solr8.2.0, solr9.4.0, solr9.6.1, traefik-base, traefik, haproxy-base, haproxy, openldap-base, openldap, phpmemcachedadmin-base, phpmemcachedadmin, phpldapadmin, dbadminer, mailcatcher
+**Serviços:** memcached, jod, jod4.4.8, solr8.2.0, solr9.4.0, solr9.6.1, traefik-base, traefik, haproxy-base, haproxy, openldap-base, openldap, phpmemcachedadmin-base, phpmemcachedadmin, phpldapadmin, dbadminer, mailcatcher
 
 ---
 
@@ -60,15 +60,15 @@ Os testes combinam **modalidades de deploy** com **bancos de dados**:
 | **Completa** | X | X | X | X |
 | **HTTP** | X | X | X | X |
 
-**Total:** 16 combinacoes
+**Total:** 16 combinações
 
 ### Modalidades
 
-| Modalidade | Descricao |
+| Modalidade | Descrição |
 |------------|-----------|
 | **Reduzida** | Sem load balancer, URL customizada, HTTPS |
 | **Default** | Com load balancer, localhost |
-| **Completa** | Todos os servicos opcionais habilitados, HTTPS |
+| **Completa** | Todos os serviços opcionais habilitados, HTTPS |
 | **HTTP** | Variantes HTTP (sem TLS) |
 
 ### Comandos
@@ -76,7 +76,7 @@ Os testes combinam **modalidades de deploy** com **bancos de dados**:
 ```bash
 cd infra/tests
 
-# Rodar suite completa (todas as 16 combinacoes)
+# Rodar suíte completa (todas as 16 combinações)
 make test_lineup_completa
 
 # Rodar por modalidade
@@ -85,31 +85,31 @@ make test_ambientes_default
 make test_ambientes_completa
 make test_ambientes_full
 
-# Rodar combinacao especifica
+# Rodar combinação específica
 make MODALIDADE=completa BANCO=oracle test_ambiente
 make MODALIDADE=default BANCO=mysql test_ambiente
 make MODALIDADE=reduzida BANCO=postgres test_ambiente
 ```
 
-### Arquivos de Configuracao de Teste
+### Arquivos de Configuração de Teste
 
 | Arquivo | Modalidade |
 |---------|------------|
 | `test-envlocal-reduzida.env` | Deploy reduzido |
 | `test-envlocal-http.env` | Deploy HTTP |
 | `test-envlocal-completa.env` | Deploy completo |
-| (padrao do infra) | Deploy default |
+| (padrão do infra) | Deploy default |
 
-### Validacoes Executadas
+### Validações Executadas
 
-Para cada combinacao, o teste executa:
+Para cada combinação, o teste executa:
 
-1. **Criacao de volumes** - Verifica se todos os volumes foram criados
-2. **Deploy dos servicos** - `make setup` ou `make run`
+1. **Criação de volumes** - Verifica se todos os volumes foram criados
+2. **Deploy dos serviços** - `make setup` ou `make run`
 3. **Health check do SEI** - Acessa tela de login via `curl`
-4. **Verificacao do balanceador** - Testa dashboard Traefik (se presente)
-5. **Verificacao de componentes** - JOD, admin UIs (se presentes)
-6. **Escalonamento** - Escala app de 1 -> 2 -> 3 -> 1 instancias
+4. **Verificação do balanceador** - Testa dashboard Traefik (se presente)
+5. **Verificação de componentes** - JOD, admin UIs (se presentes)
+6. **Escalonamento** - Escala app de 1 -> 2 -> 3 -> 1 instâncias
 7. **Testes Selenium** - Workflow funcional completo
 8. **Limpeza** - `make clear && make apagar_volumes`
 
@@ -122,11 +122,11 @@ Para cada combinacao, o teste executa:
 
 ### Workflow Testado
 
-O teste Selenium simula um usuario completo:
+O teste Selenium simula um usuário completo:
 
 1. **Login** - Acessa SEI e faz login com credenciais
-2. **Validacao de modulos** - Verifica se modulos instalados estao disponiveis
-3. **Criacao de processo** - Cria um novo processo eletronico
+2. **Validação de módulos** - Verifica se módulos instalados estão disponíveis
+3. **Criação de processo** - Cria um novo processo eletrônico
 4. **Documento com anexo** - Cria documento e anexa arquivo
 5. **Documento interno** - Cria documento interno no processo
 6. **Logout** - Realiza logout e verifica redirecionamento
@@ -135,10 +135,10 @@ O teste Selenium simula um usuario completo:
 
 - **Driver:** Chrome headless via Docker (`selenium/standalone-chrome`)
 - **Rede:** Docker network ou host networking
-- **Tentativas:** Ate 3 retentativas por teste
-- **Relatorio:** XML JUnit (`resultado.xml`)
+- **Tentativas:** Até 3 retentativas por teste
+- **Relatório:** XML JUnit (`resultado.xml`)
 
-### Execucao Manual
+### Execução Manual
 
 ```bash
 cd infra/tests
@@ -150,7 +150,7 @@ docker run --rm \
   selenium/standalone-chrome \
   python3 /tests/PythonExported/test_suiteBasics.py
 
-# Variaveis de ambiente para o teste
+# Variáveis de ambiente para o teste
 export SEI_URL="https://localhost/sei"
 export SEI_USUARIO="teste"
 export SEI_SENHA="teste"
@@ -165,19 +165,19 @@ export SEI_SENHA="teste"
 
 ### O que testa
 
-Executa testes funcionais Selenium em todas as combinacoes de banco de dados no ambiente de desenvolvimento.
+Executa testes funcionais Selenium em todas as combinações de banco de dados no ambiente de desenvolvimento.
 
-### Restricoes
+### Restrições
 
 - Funciona apenas em **Linux** (usa Docker host networking)
 - Requer `localhost` como URL do SEI
-- Codigo-fonte deve estar disponivel em `SEI_PATH`
+- Código-fonte deve estar disponível em `SEI_PATH`
 
 ---
 
-## Deteccao de Docker Compose
+## Detecção de Docker Compose
 
-Todos os Makefiles detectam automaticamente a versao do Docker Compose:
+Todos os Makefiles detectam automaticamente a versão do Docker Compose:
 
 ```makefile
 # Detecta "docker compose" (v2) ou "docker-compose" (v1)
@@ -193,7 +193,7 @@ DC := $(shell docker compose version 2>/dev/null && echo "docker compose" || ech
 **Caminho:** `infra/jenkins/`
 **Status:** Placeholder (`comminganytime.txt`)
 
-A integracao com Jenkins e prevista mas nao implementada. Atualmente o CI/CD e feito via Makefiles.
+A integração com Jenkins é prevista mas não implementada. Atualmente o CI/CD é feito via Makefiles.
 
 ### Pipeline de CI Recomendado
 
@@ -202,7 +202,7 @@ A integracao com Jenkins e prevista mas nao implementada. Atualmente o CI/CD e f
    make build-conteiner-base-centos
    make build-conteiner-base-rocky93
 
-2. Build de imagens de servico
+2. Build de imagens de serviço
    make build-conteiners
 
 3. Teste de containers
@@ -211,9 +211,9 @@ A integracao com Jenkins e prevista mas nao implementada. Atualmente o CI/CD e f
 4. Deploy de teste
    cd infra && make setup
 
-5. Testes de integracao
+5. Testes de integração
    cd infra/tests && make test_lineup_completa
 
-6. Publicacao
+6. Publicação
    cd containers && make publish-containers
 ```

--- a/docs/variaveis-ambiente.md
+++ b/docs/variaveis-ambiente.md
@@ -1,0 +1,521 @@
+# Variaveis de Ambiente - Referencia Completa
+
+Referencia de todas as variaveis de ambiente do projeto SEI-Docker, organizadas por categoria. Sao aproximadamente **230+ variaveis** distribuidas entre os arquivos de configuracao.
+
+---
+
+## Arquivos de Configuracao
+
+| Arquivo | Escopo | Descricao |
+|---------|--------|-----------|
+| `infra/envlocal.env` | Infraestrutura | Configuracao principal com 100+ variaveis |
+| `containers/envcontainers.env.modelo` | Build | Template para build de imagens Docker |
+| `dev/envs/env-{banco}-{versao}.env` | Desenvolvimento | Config por combinacao banco/versao (8 arquivos) |
+
+---
+
+## 1. Caminhos e Controle de Build
+
+**Arquivo:** `infra/envlocal.env`
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `LOCALIZACAO_FONTES_SEI` | `~/sei/FonteSEI` | Caminho absoluto no host para o codigo-fonte do SEI. Deve conter as pastas `infra`, `sei` e `sip` |
+| `LOCALIZACAO_CERTS` | `~/sei/certs` | Caminho no host para certificados SSL. Criar vazio; certificados auto-assinados sao gerados automaticamente |
+| `MAKEFILE_MODO_VERBOSE` | `false` | Quando `true`, Makefile imprime todos os comandos executados |
+| `DOCKER_COMPOSE_BUILD` | `true` | Manter build dentro do docker-compose (nao funcional com Rancher) |
+
+---
+
+## 2. Docker Registry
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `DOCKER_REGISTRY` | `processoeletronico` | Prefixo do registry Docker para todas as imagens |
+
+---
+
+## 3. Volumes Docker
+
+**Arquivo:** `infra/envlocal.env`
+
+Todos os volumes devem ser criados mesmo quando nao utilizados. Volumes persistem dados entre rebuilds e sao os unicos itens que precisam de backup.
+
+### Volume do Banco de Dados
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `VOLUME_DB` | `local-storage-db` | Nome do volume Docker para dados do banco |
+| `VOLUME_DB_EXTERNAL` | `true` | Volume gerenciado externamente |
+| `VOLUME_DB_DRIVER` | `local` | Driver do volume |
+| `VOLUME_DB_MOUNT` | `local-storage-db` | Ponto de montagem do volume |
+| `DB_DATA_DIRECTORY` | `/var/lib/mysql` | Diretorio interno no container onde o banco armazena dados |
+
+### Volume de Arquivos Externos
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `VOLUME_ARQUIVOSEXTERNOS` | `local-arquivosexternos-storage` | Volume para armazenamento de arquivos (anexos do SEI) |
+| `VOLUME_ARQUIVOSEXTERNOS_EXTERNAL` | `false` | Volume gerenciado externamente |
+| `VOLUME_ARQUIVOSEXTERNOS_DRIVER` | `local` | Driver do volume |
+| `VOLUME_ARQUIVOSEXTERNOS_MOUNT` | `local-arquivosexternos-storage` | Ponto de montagem |
+
+### Volume de Codigo-Fonte
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `VOLUME_FONTES` | `local-fontes-storage` | Volume para codigo-fonte do SEI |
+| `VOLUME_FONTES_MOUNT` | `local-fontes-storage` | Ponto de montagem |
+
+### Volume de Certificados
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `VOLUME_CERTS` | `local-certs-storage` | Volume para certificados SSL |
+| `VOLUME_CERTS_MOUNT` | `local-certs-storage` | Ponto de montagem |
+
+### Volume do Solr
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `VOLUME_SOLR` | `local-volume-solr` | Volume para dados do Solr |
+| `SOLR_DATA_DIRECTORY` | `/dados` | Diretorio interno de dados do Solr |
+
+### Volumes do OpenLDAP
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `VOLUME_OPENLDAP_SLAPD` | `local-openldap-slapd-storage` | Volume para config slapd |
+| `VOLUME_OPENLDAP_SLAPD_EXTERNAL` | `false` | Volume gerenciado externamente |
+| `VOLUME_OPENLDAP_SLAPD_DRIVER` | `local` | Driver do volume |
+| `VOLUME_OPENLDAP_SLAPD_MOUNT` | `local-openldap-slapd-storage` | Ponto de montagem |
+| `VOLUME_OPENLDAP_DB` | `local-openldap-db-storage` | Volume para dados LDAP |
+| `VOLUME_OPENLDAP_DB_EXTERNAL` | `false` | Volume gerenciado externamente |
+| `VOLUME_OPENLDAP_DB_DRIVER` | `local` | Driver do volume |
+| `VOLUME_OPENLDAP_DB_MOUNT` | `local-openldap-db-storage` | Ponto de montagem |
+
+### Volume do Controlador de Instalacao
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `VOLUME_CONTROLADOR_INSTALACAO` | `local-controlador-instalacao-storage` | Volume para rastrear estado de instalacao de modulos |
+| `VOLUME_CONTROLADOR_INSTALACAO_EXTERNAL` | `false` | Volume gerenciado externamente |
+| `VOLUME_CONTROLADOR_INSTALACAO_DB_DRIVER` | `local` | Driver do volume |
+| `VOLUME_CONTROLADOR_INSTALACAO_MOUNT` | `local-controlador-instalacao-storage` | Ponto de montagem |
+
+---
+
+## 4. Load Balancer (Traefik)
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `DOCKER_IMAGE_BALANCEADOR` | `${DOCKER_REGISTRY}/traefik:latest` | Imagem Docker do Traefik |
+| `BALANCEADOR_PRESENTE` | `true` | Habilitar load balancer |
+| `BALANCEADOR_PORTA_80_MAP_EXPOR` | `true` | Expor porta 80 no host |
+| `BALANCEADOR_PORTA_80_MAP` | `80:80` | Mapeamento da porta HTTP |
+| `BALANCEADOR_PORTA_443_MAP_EXPOR` | `true` | Expor porta 443 no host |
+| `BALANCEADOR_PORTA_443_MAP` | `443:443` | Mapeamento da porta HTTPS |
+
+---
+
+## 5. Imagens Docker dos Servicos
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `DOCKER_IMAGE_APP` | `${DOCKER_REGISTRY}/app-ci:latest` | Imagem da aplicacao SEI principal |
+| `DOCKER_IMAGE_APP_AGENDADOR` | `${DOCKER_REGISTRY}/app-ci-agendador:latest` | Imagem do agendador de tarefas |
+| `DOCKER_IMAGE_BD` | `${DOCKER_REGISTRY}/mariadb10.5-sei40:latest` | Imagem do banco de dados |
+| `DOCKER_IMAGE_SOLR` | `${DOCKER_REGISTRY}/solr8.2.0:latest` | Imagem do Apache Solr |
+| `DOCKER_IMAGE_MEMCACHED` | `${DOCKER_REGISTRY}/memcached:latest` | Imagem do Memcached |
+| `DOCKER_IMAGE_JOD` | `${DOCKER_REGISTRY}/jod:latest` | Imagem do JOD Converter |
+| `DOCKER_IMAGE_MAIL` | `${DOCKER_REGISTRY}/mailcatcher:latest` | Imagem do MailCatcher |
+| `DOCKER_IMAGE_OPENLDAP` | `${DOCKER_REGISTRY}/openldap:latest` | Imagem do OpenLDAP |
+| `DOCKER_IMAGE_OPENLDAP_PHPLDAPADMIN` | `${DOCKER_REGISTRY}/phpldapadmin:latest` | Imagem do phpLDAPadmin |
+| `DOCKER_IMAGE_MEMCACHEDADMIN` | `${DOCKER_REGISTRY}/phpmemcachedadmin:latest` | Imagem do admin Memcached |
+| `DOCKER_IMAGE_DBADMIN` | `${DOCKER_REGISTRY}/dbadminer:latest` | Imagem do Adminer (admin BD) |
+
+---
+
+## 6. Toggles de Servicos Opcionais
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `JOD_PRESENTE` | `true` | Habilitar conversao de documentos |
+| `DBADMIN_PRESENTE` | `false` | Habilitar Adminer (disponivel em `/dbadmin`) |
+| `MEMCACHEDADMIN_PRESENTE` | `false` | Habilitar admin Memcached (disponivel em `/memcachedadmin`) |
+| `MAIL_CATCHER_PRESENTE` | `false` | Habilitar MailCatcher (disponivel em `/mailadmin`) |
+| `OPENLDAP_PRESENTE` | `false` | Habilitar OpenLDAP. Quando `true`, SEI usa LDAP para autenticacao |
+| `BALANCEADOR_PRESENTE` | `true` | Habilitar Traefik como load balancer |
+
+---
+
+## 7. Portas da Aplicacao
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `APP_PORTA_80_MAP_EXPOR` | `false` | Expor porta 80 diretamente no container app (usar sem load balancer) |
+| `APP_PORTA_80_MAP` | `80:80` | Mapeamento HTTP no app |
+| `APP_PORTA_443_MAP_EXPOR` | `false` | Expor porta 443 diretamente no container app |
+| `APP_PORTA_443_MAP` | `443:443` | Mapeamento HTTPS no app |
+
+---
+
+## 8. Configuracao da Aplicacao
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `APP_PROTOCOLO` | `https` | Protocolo: `http` ou `https`. Controla Traefik e geracao de certificados |
+| `APP_HOST` | `localhost` | Hostname/URL do SEI. Pode ser DNS real ou mapeado em /etc/hosts |
+| `APP_ORGAO` | `ME` | Sigla do orgao |
+| `APP_ORGAO_DESCRICAO` | `Orgao Processo Eletronico - MySql` | Descricao completa do orgao |
+| `APP_ORGAOS_ADICIONAIS_SIGLA` | *(vazio)* | Siglas de orgaos adicionais separadas por `/` |
+| `APP_ORGAOS_ADICIONAIS_NOME` | *(vazio)* | Nomes de orgaos adicionais separados por `/` |
+| `APP_FEDERACAO_HABILITAR` | `false` | Habilitar modo federacao do SEI |
+| `APP_NOMECOMPLEMENTO` | `SEI - PEN - DTH` | Nome complementar exibido no SEI |
+
+---
+
+## 9. Sessoes Memcached
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `APP_MEMCACHED_HOST` | `memcached` | Hostname do servico Memcached |
+| `APP_MEMCACHED_SESSION` | `false` | Quando `true`, sessoes PHP sao armazenadas no Memcached (necessario para balanceamento sem sticky session). Funciona apenas com SEI 5 |
+
+---
+
+## 10. Gerenciamento de Fontes via Git
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `APP_FONTES_GIT_PATH` | *(vazio)* | Caminho SSH do repositorio Git dos fontes. Ex: `git@github.com:supergovbr/super` |
+| `APP_FONTES_GIT_PRIVKEY_BASE64` | *(vazio)* | Chave privada SSH codificada em Base64 para clonar o repositorio |
+| `APP_FONTES_GITHUB_TOKEN` | *(vazio)* | Token GitHub para download de tarball. Tem precedencia sobre `APP_FONTES_GIT_PRIVKEY_BASE64` |
+| `APP_FONTES_GIT_CHECKOUT` | *(vazio)* | Branch, tag ou commit para checkout. Ex: `main`, `4.0.3.3` |
+
+---
+
+## 11. Conexao com Banco de Dados
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `APP_DB_TIPO` | `MySql` | Tipo do banco. Valores: `MySql`, `SqlServer`, `Oracle`, `PostgreSql` |
+| `APP_DB_HOST` | `db` | Hostname do container de banco |
+| `APP_DB_PORTA` | `3306` | Porta do banco de dados |
+| `APP_DB_SEI_BASE` | `sei` | Nome da base de dados do SEI |
+| `APP_DB_SEI_USERNAME` | `sei_user` | Usuario do banco SEI |
+| `APP_DB_SEI_PASSWORD` | `sei_user` | Senha do banco SEI |
+| `APP_DB_SIP_BASE` | `sip` | Nome da base de dados do SIP |
+| `APP_DB_SIP_USERNAME` | `sip_user` | Usuario do banco SIP |
+| `APP_DB_SIP_PASSWORD` | `sip_user` | Senha do banco SIP |
+| `APP_DB_ROOT_USERNAME` | `root` | Usuario root/admin do banco |
+| `APP_DB_ROOT_PASSWORD` | `P@ssword` | Senha root/admin do banco |
+
+---
+
+## 12. Chaves de Acesso SEI/SIP
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `APP_SEI_CHAVE_ACESSO` | `7babf862e12b...6135dc` | Token de autenticacao inter-sistema do SEI |
+| `APP_SIP_CHAVE_ACESSO` | `d27791b89402...fb933` | Token de autenticacao inter-sistema do SIP |
+
+---
+
+## 13. Configuracao do Solr
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `APP_SOLR_URL` | `http://solr:8983/solr` | URL base do Solr |
+| `APP_SOLR_CORE_PROTOCOLOS` | `sei-protocolos` | Core para documentos de protocolo |
+| `APP_SOLR_TEMPO_COMMIT_PROTOCOLOS` | `300` | Intervalo de auto-commit (segundos) |
+| `APP_SOLR_CORE_BASECONHECIMENTO` | `sei-bases-conhecimento` | Core para base de conhecimento |
+| `APP_SOLR_TEMPO_COMMIT_BASECONHECIMENTO` | `60` | Intervalo de auto-commit (segundos) |
+| `APP_SOLR_CORE_PUBLICACOES` | `sei-publicacoes` | Core para publicacoes |
+| `APP_SOLR_TEMPO_COMMIT_PUBLICACOES` | `60` | Intervalo de auto-commit (segundos) |
+
+---
+
+## 14. Configuracao de E-mail (SMTP)
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `APP_MAIL_TIPO` | `2` | Metodo de envio. `1` = sendmail, `2` = SMTP |
+| `APP_MAIL_SERVIDOR` | `mail` | Servidor SMTP |
+| `APP_MAIL_PORTA` | `25` | Porta SMTP |
+| `APP_MAIL_CODIFICACAO` | `8bit` | Codificacao: `8bit`, `7bit`, `binary`, `base64`, `quoted-printable` |
+| `APP_MAIL_MAXDESTINATARIOS` | `999` | Maximo de destinatarios por e-mail |
+| `APP_MAIL_MAXTAMANHOANEXOSMB` | `999` | Tamanho maximo de anexos (MB) |
+| `APP_MAIL_SEGURANCA` | *(vazio)* | Seguranca SMTP: `/TLS`, `SSL`, ou vazio |
+| `APP_MAIL_AUTENTICAR` | *(vazio)* | Habilitar autenticacao SMTP |
+| `APP_MAIL_USUARIO` | *(vazio)* | Usuario SMTP |
+| `APP_MAIL_SENHA` | *(vazio)* | Senha SMTP |
+| `APP_MAIL_PROTEGIDO` | *(vazio)* | E-mail de redirecionamento em dev. Quando definido, TODOS os e-mails sao desviados para este endereco |
+
+---
+
+## 15. OpenLDAP
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `OPENLDAP_PRESENTE` | `false` | Habilitar OpenLDAP |
+| `OPENLDAP_ADMIN_PASSWORD` | `adminldap` | Senha admin LDAP. Login: `cn=admin,dc=pen,dc=gov,dc=br` |
+| `OPENLDAP_DESLIGAR_NO_ORGAO_0` | `false` | Forcar desativacao do LDAP para orgao 0 |
+
+---
+
+## 16. Protocolo Digital
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `SERVICO_PD_INSTALAR` | `false` | Instalar integracao Protocolo Digital |
+| `SERVICO_PD_SIGLA` | `GOV.BR` | Sigla do servico |
+| `SERVICO_PD_NOME` | `Protocolo.GOV.BR` | Nome do servico |
+| `SERVICO_PD_OPERACOES` | `3,2,15,0,1` | IDs das operacoes habilitadas |
+
+---
+
+## 17. Credenciais Git para Modulos
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `GITUSER_REPO_MODULOS` | `dummy` | Usuario Git para repositorios de modulos privados |
+| `GITPASS_REPO_MODULOS` | `dummy` | Senha/token Git para repositorios de modulos |
+
+---
+
+## 18. Modulo Estatisticas
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `MODULO_ESTATISTICAS_INSTALAR` | `true` | Instalar modulo de estatisticas |
+| `MODULO_ESTATISTICAS_VERSAO` | `master` | Branch/tag do repositorio |
+| `MODULO_ESTATISTICAS_URL` | `https://estatistica.dev.processoeletronico.gov.br` | URL do servico de estatisticas |
+| `MODULO_ESTATISTICAS_SIGLA` | `SEIPUBLICO` | Sigla da credencial (publica para dev) |
+| `MODULO_ESTATISTICAS_CHAVE` | `seipublico` | Chave da credencial |
+
+---
+
+## 19. Modulo REST / WSSEI
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `MODULO_REST_INSTALAR` | `false` | Instalar modulo REST |
+| `MODULO_REST_VERSAO` | `master` | Branch/tag |
+| `MODULO_REST_URL_NOTIFICACAO` | *(vazio)* | URL do servico de notificacoes push |
+| `MODULO_REST_ID_APP` | *(vazio)* | ID da aplicacao para push |
+| `MODULO_REST_CHAVE` | *(vazio)* | Chave de autorizacao |
+| `MODULO_REST_TOKEN_SECRET` | *(vazio)* | Secret para tokens |
+
+---
+
+## 20. Modulo Gestao Documental
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `MODULO_GESTAODOCUMENTAL_INSTALAR` | `false` | Instalar modulo de gestao documental |
+| `MODULO_GESTAODOCUMENTAL_VERSAO` | `master` | Branch/tag |
+
+---
+
+## 21. Modulo Resposta
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `MODULO_RESPOSTA_INSTALAR` | `false` | Instalar modulo de resposta |
+| `MODULO_RESPOSTA_VERSAO` | `master` | Branch/tag |
+
+---
+
+## 22. Modulo Login Unico (GOV.BR)
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `MODULO_LOGINUNICO_INSTALAR` | `false` | Instalar modulo Login Unico |
+| `MODULO_LOGINUNICO_VERSAO` | `master` | Branch/tag |
+| `MODULO_LOGINUNICO_CLIENTID` | `sistemas/homologacao/sei/controlador_externo` | Client ID OAuth2 |
+| `MODULO_LOGINUNICO_SECRET` | `XXXX` | Client Secret OAuth2 |
+| `MODULO_LOGINUNICO_URLPROVIDER` | `https://sso.staging.acesso.gov.br/` | URL do provedor OAuth2 (SSO) |
+| `MODULO_LOGINUNICO_REDIRECTURL` | `http://sei.xxx.nuvem.gov.br/.../controlador_loginunico.php` | URL de callback |
+| `MODULO_LOGINUNICO_URLLOGOUT` | `http://sei.xxx.nuvem.gov.br/.../logout.php` | URL de logout |
+| `MODULO_LOGINUNICO_SCOPE` | `openid+email+phone+profile+govbr_empresa+govbr_confiabilidades` | Escopos OAuth2 |
+| `MODULO_LOGINUNICO_URLSERVICOS` | `https://api.staging.acesso.gov.br/` | URL dos servicos GOV.BR |
+| `MODULO_LOGINUNICO_URLREVALIDACAO` | `https://oauth.staging.acesso.gov.br/v1/` | Endpoint de revalidacao |
+| `MODULO_LOGINUNICO_CIENTIDVALIDACAO` | `sei.xxx.nuvem.gov.br/validacaosenha` | Client ID para revalidacao |
+| `MODULO_LOGINUNICO_SECRETVALIDACAO` | `XXX` | Secret para revalidacao |
+| `MODULO_LOGINUNICO_ORGAO` | `0` | ID do orgao para integracao |
+
+---
+
+## 23. Modulo Assinatura Avancada
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `MODULO_ASSINATURA_INSTALAR` | `false` | Instalar modulo de assinatura eletronica |
+| `MODULO_ASSINATURA_VERSAO` | `master` | Branch/tag |
+| `MODULO_ASSINATURA_URLPROVIDER` | `https://cas.staging.iti.br/oauth2.0` | Provedor OAuth2 para assinatura |
+| `MODULO_ASSINATURA_CLIENTID` | `assinaturaAvancadaXXX` | Client ID |
+| `MODULO_ASSINATURA_SECRET` | `XXX` | Client Secret |
+| `MODULO_ASSINATURA_VALIDAR_API_URL` | `https://informarurl` | URL da API de validacao |
+| `MODULO_ASSINATURA_VALIDAR_API_KEY` | `XXX` | Chave da API de validacao |
+| `MODULO_ASSINATURA_TOKEN_URL` | `XX` | URL para obtencao de token |
+| `MODULO_ASSINATURA_TOKEN_SIGN_URL` | `XX` | URL para assinatura de token |
+| `MODULO_ASSINATURA_INTEGRA_ICP_URL` | `https://informar` | URL base ICP-Brasil |
+| `MODULO_ASSINATURA_INTEGRA_ICP_URL_CLEARINGS` | `/get-clearings` | Endpoint de clearings ICP |
+| `MODULO_ASSINATURA_INTEGRA_ICP_URL_ASSINAR` | `/sign` | Endpoint de assinatura ICP |
+| `MODULO_ASSINATURA_CLOUDPSC_URL` | `XXX` | URL do Cloud PSC |
+| `MODULO_ASSINATURA_CLOUDPSC_START_URL` | `XXX` | URL de inicio Cloud PSC |
+| `MODULO_ASSINATURA_CLOUDPSC_SIGN_URL` | `XXX` | URL de assinatura Cloud PSC |
+| `MODULO_ASSINATURA_API_KEY_ITYHY` | `XXX` | Chave API ITI/Hy |
+
+---
+
+## 24. Modulo PEN / Barramento
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `MODULO_PEN_INSTALAR` | `false` | Instalar modulo PEN (tramitacao entre orgaos) |
+| `MODULO_PEN_VERSAO` | `master` | Branch/tag |
+| `MODULO_PEN_WEBSERVICE` | `https://homolog.api.processoeletronico.gov.br/.../v3/` | Endpoint SOAP do Barramento |
+| `MODULO_PEN_CERTIFICADO_SENHA` | `1234` | Senha do certificado PEM |
+| `MODULO_PEN_CERTIFICADO_BASE64` | *(base64 longo)* | Certificado PEM em Base64 (cert + chave privada) |
+| `MODULO_PEN_GEARMAN_IP` | *(vazio)* | IP do servidor Gearman |
+| `MODULO_PEN_GEARMAN_PORTA` | *(vazio)* | Porta do Gearman |
+| `MODULO_PEN_QTD_WORKER_PROC` | `1` | Numero de workers Gearman para PEN |
+| `MODULO_PEN_REPOSITORIO_ORIGEM` | *(vazio)* | Repositorio de origem (auto-config) |
+| `MODULO_PEN_TIPO_PROCESSO_EXTERNO` | *(vazio)* | Tipo de processo para recebimentos externos |
+| `MODULO_PEN_UNIDADE_GERADORA` | *(vazio)* | Unidade geradora para processos recebidos |
+| `MODULO_PEN_UNIDADE_ASSOCIACAO_PEN` | *(vazio)* | ID da unidade PEN para associacao |
+| `MODULO_PEN_UNIDADE_ASSOCIACAO_SEI` | *(vazio)* | ID da unidade SEI para associacao |
+
+---
+
+## 25. Modulo Peticionamento
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `MODULO_PETICIONAMENTO_INSTALAR` | `false` | Instalar modulo de peticionamento eletronico |
+| `MODULO_PETICIONAMENTO_VERSAO` | `master` | Branch/tag |
+| `MODULO_PETICIONAMENTO_URL` | `https://github.com/anatelgovbr/mod-sei-peticionamento` | URL do repositorio |
+
+---
+
+## 26. Modulo Protocolo Integrado
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `MODULO_PI_INSTALAR` | `false` | Instalar modulo Protocolo Integrado |
+| `MODULO_PI_VERSAO` | `master` | Branch/tag |
+| `MODULO_PI_URL` | `https://protocolointegrado.preprod.nuvem.gov.br/.../integradorService?wsdl` | WSDL do web service |
+| `MODULO_PI_USUARIO` | `usuariodeconexaopi` | Usuario de conexao |
+| `MODULO_PI_SENHA` | `senhadeconexaoaopi` | Senha de conexao |
+| `MODULO_PI_EMAIL` | `email@example.com` | E-mail de contato |
+
+---
+
+## 27. Modulo INCOM (Imprensa Nacional)
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `MODULO_INCOM_INSTALAR` | `false` | Instalar modulo INCOM |
+| `MODULO_INCOM_VERSAO` | `v1.0.4` | Branch/tag |
+| `MODULO_INCOM_VEICULOID` | `2` | ID do veiculo de publicacao |
+| `MODULO_INCOM_SERIEID` | `10` | ID da serie documental |
+| `MODULO_INCOM_SIORG` | `235876` | Codigo SIORG do orgao |
+| `MODULO_INCOM_URLWS` | `https://seiwsincom2.in.gov.br/.../servicoIN?wsdl` | WSDL do web service INCOM |
+| `MODULO_INCOM_USERWS` | `XXX` | Usuario do web service |
+| `MODULO_INCOM_PASSWS` | `XXX` | Senha do web service |
+| `MODULO_INCOM_INCLUSAOPUBLICACAO` | `S` | Incluir publicacao (`S` = Sim) |
+
+---
+
+## 28. Kubernetes
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `KUBERNETES_NAMESPACE` | `seins` | Namespace Kubernetes |
+| `KUBERNETES_PVC_STORAGECLASS` | `nfs-client` | Storage class para PVCs |
+| `KUBERNETES_RESOURCES_INFORMAR` | `true` | Incluir limites de recursos nos manifests |
+
+### Limites de Recursos por Servico
+
+| Servico | CPU Limit | Memory Limit | CPU Request | Memory Request |
+|---------|-----------|-------------|-------------|----------------|
+| Memcached | `500m` | `512Mi` | `500m` | `512Mi` |
+| JOD | `500m` | `512Mi` | `500m` | `512Mi` |
+| Solr | `500m` | `1Gi` | `500m` | `1Gi` |
+| Banco de Dados | `500m` | `1Gi` | `500m` | `1Gi` |
+| Aplicacao | `500m` | `1Gi` | `500m` | `1Gi` |
+| Agendador | `500m` | `1Gi` | `500m` | `1Gi` |
+
+**Variaveis:** `KUBERNETES_LIMITS_CPU_{SERVICO}`, `KUBERNETES_LIMITS_MEMORY_{SERVICO}`, `KUBERNETES_REQUEST_CPU_{SERVICO}`, `KUBERNETES_REQUEST_MEMORY_{SERVICO}`
+
+---
+
+## 29. Variaveis de Build de Containers
+
+**Arquivo:** `containers/envcontainers.env.modelo`
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `DOCKER_CONTAINER_VERSAO_PRODUTO` | `3.6.11` | Versao do produto para tags das imagens |
+
+### Imagens Base
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `IMAGEM_BASE_CENTOS` | `${DOCKER_REGISTRY}/base-centos7` | Imagem base CentOS |
+| `IMAGEM_BASE_ROCKY93` | `${DOCKER_REGISTRY}/base-rocky93` | Imagem base Rocky Linux |
+| `IMAGEM_BASE_MARIADB` | `${DOCKER_REGISTRY}/base-mariadb10.5` | Imagem base MariaDB |
+| `IMAGEM_BASE_MYSQL8` | `${DOCKER_REGISTRY}/base-mysql8` | Imagem base MySQL 8 |
+| `IMAGEM_BASE_SQLSERVER` | `${DOCKER_REGISTRY}/base-sqlserver2019` | Imagem base SQL Server |
+| `IMAGEM_BASE_ORACLE` | `${DOCKER_REGISTRY}/base-oracle11g` | Imagem base Oracle |
+| `IMAGEM_BASE_POSTGRES` | `${DOCKER_REGISTRY}/base-postgres15` | Imagem base PostgreSQL |
+| `IMAGEM_BASE_APP` | `${DOCKER_REGISTRY}/base-app` | Imagem base App PHP 7 |
+| `IMAGEM_BASE_APP_PHP8` | `${DOCKER_REGISTRY}/base-app-php8` | Imagem base App PHP 8 |
+| `IMAGEM_BASE_APP_AGENDADOR` | `${DOCKER_REGISTRY}/app-ci` | Imagem base Agendador PHP 7 |
+| `IMAGEM_BASE_APP_PHP8_AGENDADOR` | `${DOCKER_REGISTRY}/app-ci-php8` | Imagem base Agendador PHP 8 |
+| `IMAGEM_BASE_HAPROXY` | `${DOCKER_REGISTRY}/haproxy-base` | Imagem base HAProxy |
+| `IMAGEM_BASE_TRAEFIK` | `${DOCKER_REGISTRY}/traefik-base` | Imagem base Traefik |
+| `IMAGEM_BASE_OPENLDAP` | `${DOCKER_REGISTRY}/openldap-base` | Imagem base OpenLDAP |
+| `IMAGEM_BASE_PHPMEMCACHEDADMIN` | `${DOCKER_REGISTRY}/phpmemcachedadmin-base` | Imagem base admin Memcached |
+
+Cada variavel possui uma correspondente `*_VERSAO` com padrao `latest`.
+
+---
+
+## 30. Variaveis do Ambiente de Desenvolvimento
+
+**Arquivos:** `dev/envs/env-{banco}-{versao}.env`
+
+| Variavel | MySQL | PostgreSQL | Oracle | SQL Server | Descricao |
+|----------|-------|-----------|--------|------------|-----------|
+| `ENVIRONMENT_VERSION` | `3.6.7` | `3.6.7` | `3.6.7` | `3.6.7` | Versao do ambiente dev |
+| `DATABASE_IMAGE` | `mysql8-sei50` | `postgres15-sei50` | `oracle11g-sei50` | `sqlserver2019-sei50` | Imagem do banco |
+| `DATABASE_TYPE` | `MySql` | `PostgreSql` | `Oracle` | `SqlServer` | Tipo do banco |
+| `DATABASE_HOST` | `mysql` | `postgres` | `oracle` | `sqlserver` | Hostname do banco |
+| `DATABASE_PORT` | `3306` | `5432` | `1521` | `1433` | Porta do banco |
+| `DATABASE_DATA_DIR` | `/var/lib/mysql` | `/var/lib/postgresql/data` | `/u01/app/oracle` | `/var/opt/mssql/data` | Diretorio de dados |
+| `APP_IMAGE` | `app-dev-php8` | `app-dev-php8` | `app-dev-php8` | `app-dev-php8` | Imagem do app |
+| `SOLR_IMAGE` | `solr9.6.1` | `solr9.6.1` | `solr9.6.1` | `solr9.6.1` | Imagem do Solr |
+| `JOD_IMAGE` | `jod4.4.8` | `jod4.4.8` | `jod4.4.8` | `jod4.4.8` | Imagem do JOD |
+
+### Credenciais do Banco (Dev)
+
+| Variavel | MySQL/PostgreSQL | Oracle | Descricao |
+|----------|-----------------|--------|-----------|
+| `SEI_DATABASE_USER` | `sei_user` | `sei` | Usuario SEI |
+| `SIP_DATABASE_USER` | `sip_user` | `sip` | Usuario SIP |
+| `SEI_DATABASE_USER_SCRIPT` | `sei_user` / `postgres` | `sei` | Usuario para scripts de update |
+| `SEI_DATABASE_PASSWORD_SCRIPT` | `sei_user` / `P@ssword` | `sei_user` | Senha para scripts |
+
+### Variaveis de Runtime (docker-compose.yml dev)
+
+| Variavel | Padrao | Descricao |
+|----------|--------|-----------|
+| `SEI_PATH` | *(obrigatorio)* | Caminho do codigo-fonte no host, montado em `/opt/` |
+| `HOST_IP` | *(obrigatorio)* | IP do host para XDebug |
+| `HOST_URL` | `http://localhost:8000` | URL do SEI no ambiente dev |
+| `XDEBUG_CONFIG` | `idekey=default client_host=${HOST_IP} client_port=9003 discover_client_host=1` | Config do XDebug |
+| `XDEBUG_SESSION` | `default` | Nome da sessao/IDE key do XDebug |
+| `XDEBUG_MODE` | `debug` | Modo do XDebug: `debug`, `profile`, `trace` |

--- a/docs/variaveis-ambiente.md
+++ b/docs/variaveis-ambiente.md
@@ -1,16 +1,16 @@
-# Variaveis de Ambiente - Referencia Completa
+# Variáveis de Ambiente - Referência Completa
 
-Referencia de todas as variaveis de ambiente do projeto SEI-Docker, organizadas por categoria. Sao aproximadamente **230+ variaveis** distribuidas entre os arquivos de configuracao.
+Referência de todas as variáveis de ambiente do projeto SEI-Docker, organizadas por categoria. São aproximadamente **230+ variáveis** distribuídas entre os arquivos de configuração.
 
 ---
 
-## Arquivos de Configuracao
+## Arquivos de Configuração
 
-| Arquivo | Escopo | Descricao |
+| Arquivo | Escopo | Descrição |
 |---------|--------|-----------|
-| `infra/envlocal.env` | Infraestrutura | Configuracao principal com 100+ variaveis |
+| `infra/envlocal.env` | Infraestrutura | Configuração principal com 100+ variáveis |
 | `containers/envcontainers.env.modelo` | Build | Template para build de imagens Docker |
-| `dev/envs/env-{banco}-{versao}.env` | Desenvolvimento | Config por combinacao banco/versao (8 arquivos) |
+| `dev/envs/env-{banco}-{versao}.env` | Desenvolvimento | Config por combinação banco/versão (8 arquivos) |
 
 ---
 
@@ -18,18 +18,18 @@ Referencia de todas as variaveis de ambiente do projeto SEI-Docker, organizadas 
 
 **Arquivo:** `infra/envlocal.env`
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `LOCALIZACAO_FONTES_SEI` | `~/sei/FonteSEI` | Caminho absoluto no host para o codigo-fonte do SEI. Deve conter as pastas `infra`, `sei` e `sip` |
-| `LOCALIZACAO_CERTS` | `~/sei/certs` | Caminho no host para certificados SSL. Criar vazio; certificados auto-assinados sao gerados automaticamente |
+| `LOCALIZACAO_FONTES_SEI` | `~/sei/FonteSEI` | Caminho absoluto no host para o código-fonte do SEI. Deve conter as pastas `infra`, `sei` e `sip` |
+| `LOCALIZACAO_CERTS` | `~/sei/certs` | Caminho no host para certificados SSL. Criar vazio; certificados auto-assinados são gerados automaticamente |
 | `MAKEFILE_MODO_VERBOSE` | `false` | Quando `true`, Makefile imprime todos os comandos executados |
-| `DOCKER_COMPOSE_BUILD` | `true` | Manter build dentro do docker-compose (nao funcional com Rancher) |
+| `DOCKER_COMPOSE_BUILD` | `true` | Manter build dentro do docker-compose (não funcional com Rancher) |
 
 ---
 
 ## 2. Docker Registry
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
 | `DOCKER_REGISTRY` | `processoeletronico` | Prefixo do registry Docker para todas as imagens |
 
@@ -39,51 +39,51 @@ Referencia de todas as variaveis de ambiente do projeto SEI-Docker, organizadas 
 
 **Arquivo:** `infra/envlocal.env`
 
-Todos os volumes devem ser criados mesmo quando nao utilizados. Volumes persistem dados entre rebuilds e sao os unicos itens que precisam de backup.
+Todos os volumes devem ser criados mesmo quando não utilizados. Volumes persistem dados entre rebuilds e são os únicos itens que precisam de backup.
 
 ### Volume do Banco de Dados
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
 | `VOLUME_DB` | `local-storage-db` | Nome do volume Docker para dados do banco |
 | `VOLUME_DB_EXTERNAL` | `true` | Volume gerenciado externamente |
 | `VOLUME_DB_DRIVER` | `local` | Driver do volume |
 | `VOLUME_DB_MOUNT` | `local-storage-db` | Ponto de montagem do volume |
-| `DB_DATA_DIRECTORY` | `/var/lib/mysql` | Diretorio interno no container onde o banco armazena dados |
+| `DB_DATA_DIRECTORY` | `/var/lib/mysql` | Diretório interno no container onde o banco armazena dados |
 
 ### Volume de Arquivos Externos
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
 | `VOLUME_ARQUIVOSEXTERNOS` | `local-arquivosexternos-storage` | Volume para armazenamento de arquivos (anexos do SEI) |
 | `VOLUME_ARQUIVOSEXTERNOS_EXTERNAL` | `false` | Volume gerenciado externamente |
 | `VOLUME_ARQUIVOSEXTERNOS_DRIVER` | `local` | Driver do volume |
 | `VOLUME_ARQUIVOSEXTERNOS_MOUNT` | `local-arquivosexternos-storage` | Ponto de montagem |
 
-### Volume de Codigo-Fonte
+### Volume de Código-Fonte
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `VOLUME_FONTES` | `local-fontes-storage` | Volume para codigo-fonte do SEI |
+| `VOLUME_FONTES` | `local-fontes-storage` | Volume para código-fonte do SEI |
 | `VOLUME_FONTES_MOUNT` | `local-fontes-storage` | Ponto de montagem |
 
 ### Volume de Certificados
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
 | `VOLUME_CERTS` | `local-certs-storage` | Volume para certificados SSL |
 | `VOLUME_CERTS_MOUNT` | `local-certs-storage` | Ponto de montagem |
 
 ### Volume do Solr
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
 | `VOLUME_SOLR` | `local-volume-solr` | Volume para dados do Solr |
-| `SOLR_DATA_DIRECTORY` | `/dados` | Diretorio interno de dados do Solr |
+| `SOLR_DATA_DIRECTORY` | `/dados` | Diretório interno de dados do Solr |
 
 ### Volumes do OpenLDAP
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
 | `VOLUME_OPENLDAP_SLAPD` | `local-openldap-slapd-storage` | Volume para config slapd |
 | `VOLUME_OPENLDAP_SLAPD_EXTERNAL` | `false` | Volume gerenciado externamente |
@@ -94,11 +94,11 @@ Todos os volumes devem ser criados mesmo quando nao utilizados. Volumes persiste
 | `VOLUME_OPENLDAP_DB_DRIVER` | `local` | Driver do volume |
 | `VOLUME_OPENLDAP_DB_MOUNT` | `local-openldap-db-storage` | Ponto de montagem |
 
-### Volume do Controlador de Instalacao
+### Volume do Controlador de Instalação
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `VOLUME_CONTROLADOR_INSTALACAO` | `local-controlador-instalacao-storage` | Volume para rastrear estado de instalacao de modulos |
+| `VOLUME_CONTROLADOR_INSTALACAO` | `local-controlador-instalacao-storage` | Volume para rastrear estado de instalação de módulos |
 | `VOLUME_CONTROLADOR_INSTALACAO_EXTERNAL` | `false` | Volume gerenciado externamente |
 | `VOLUME_CONTROLADOR_INSTALACAO_DB_DRIVER` | `local` | Driver do volume |
 | `VOLUME_CONTROLADOR_INSTALACAO_MOUNT` | `local-controlador-instalacao-storage` | Ponto de montagem |
@@ -107,7 +107,7 @@ Todos os volumes devem ser criados mesmo quando nao utilizados. Volumes persiste
 
 ## 4. Load Balancer (Traefik)
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
 | `DOCKER_IMAGE_BALANCEADOR` | `${DOCKER_REGISTRY}/traefik:latest` | Imagem Docker do Traefik |
 | `BALANCEADOR_PRESENTE` | `true` | Habilitar load balancer |
@@ -118,11 +118,11 @@ Todos os volumes devem ser criados mesmo quando nao utilizados. Volumes persiste
 
 ---
 
-## 5. Imagens Docker dos Servicos
+## 5. Imagens Docker dos Serviços
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `DOCKER_IMAGE_APP` | `${DOCKER_REGISTRY}/app-ci:latest` | Imagem da aplicacao SEI principal |
+| `DOCKER_IMAGE_APP` | `${DOCKER_REGISTRY}/app-ci:latest` | Imagem da aplicação SEI principal |
 | `DOCKER_IMAGE_APP_AGENDADOR` | `${DOCKER_REGISTRY}/app-ci-agendador:latest` | Imagem do agendador de tarefas |
 | `DOCKER_IMAGE_BD` | `${DOCKER_REGISTRY}/mariadb10.5-sei40:latest` | Imagem do banco de dados |
 | `DOCKER_IMAGE_SOLR` | `${DOCKER_REGISTRY}/solr8.2.0:latest` | Imagem do Apache Solr |
@@ -136,22 +136,22 @@ Todos os volumes devem ser criados mesmo quando nao utilizados. Volumes persiste
 
 ---
 
-## 6. Toggles de Servicos Opcionais
+## 6. Toggles de Serviços Opcionais
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `JOD_PRESENTE` | `true` | Habilitar conversao de documentos |
-| `DBADMIN_PRESENTE` | `false` | Habilitar Adminer (disponivel em `/dbadmin`) |
-| `MEMCACHEDADMIN_PRESENTE` | `false` | Habilitar admin Memcached (disponivel em `/memcachedadmin`) |
-| `MAIL_CATCHER_PRESENTE` | `false` | Habilitar MailCatcher (disponivel em `/mailadmin`) |
-| `OPENLDAP_PRESENTE` | `false` | Habilitar OpenLDAP. Quando `true`, SEI usa LDAP para autenticacao |
+| `JOD_PRESENTE` | `true` | Habilitar conversão de documentos |
+| `DBADMIN_PRESENTE` | `false` | Habilitar Adminer (disponível em `/dbadmin`) |
+| `MEMCACHEDADMIN_PRESENTE` | `false` | Habilitar admin Memcached (disponível em `/memcachedadmin`) |
+| `MAIL_CATCHER_PRESENTE` | `false` | Habilitar MailCatcher (disponível em `/mailadmin`) |
+| `OPENLDAP_PRESENTE` | `false` | Habilitar OpenLDAP. Quando `true`, SEI usa LDAP para autenticação |
 | `BALANCEADOR_PRESENTE` | `true` | Habilitar Traefik como load balancer |
 
 ---
 
-## 7. Portas da Aplicacao
+## 7. Portas da Aplicação
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
 | `APP_PORTA_80_MAP_EXPOR` | `false` | Expor porta 80 diretamente no container app (usar sem load balancer) |
 | `APP_PORTA_80_MAP` | `80:80` | Mapeamento HTTP no app |
@@ -160,178 +160,178 @@ Todos os volumes devem ser criados mesmo quando nao utilizados. Volumes persiste
 
 ---
 
-## 8. Configuracao da Aplicacao
+## 8. Configuração da Aplicação
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `APP_PROTOCOLO` | `https` | Protocolo: `http` ou `https`. Controla Traefik e geracao de certificados |
+| `APP_PROTOCOLO` | `https` | Protocolo: `http` ou `https`. Controla Traefik e geração de certificados |
 | `APP_HOST` | `localhost` | Hostname/URL do SEI. Pode ser DNS real ou mapeado em /etc/hosts |
-| `APP_ORGAO` | `ME` | Sigla do orgao |
-| `APP_ORGAO_DESCRICAO` | `Orgao Processo Eletronico - MySql` | Descricao completa do orgao |
-| `APP_ORGAOS_ADICIONAIS_SIGLA` | *(vazio)* | Siglas de orgaos adicionais separadas por `/` |
-| `APP_ORGAOS_ADICIONAIS_NOME` | *(vazio)* | Nomes de orgaos adicionais separados por `/` |
-| `APP_FEDERACAO_HABILITAR` | `false` | Habilitar modo federacao do SEI |
+| `APP_ORGAO` | `ME` | Sigla do órgão |
+| `APP_ORGAO_DESCRICAO` | `Orgao Processo Eletronico - MySql` | Descrição completa do órgão |
+| `APP_ORGAOS_ADICIONAIS_SIGLA` | *(vazio)* | Siglas de órgãos adicionais separadas por `/` |
+| `APP_ORGAOS_ADICIONAIS_NOME` | *(vazio)* | Nomes de órgãos adicionais separados por `/` |
+| `APP_FEDERACAO_HABILITAR` | `false` | Habilitar modo federação do SEI |
 | `APP_NOMECOMPLEMENTO` | `SEI - PEN - DTH` | Nome complementar exibido no SEI |
 
 ---
 
-## 9. Sessoes Memcached
+## 9. Sessões Memcached
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `APP_MEMCACHED_HOST` | `memcached` | Hostname do servico Memcached |
-| `APP_MEMCACHED_SESSION` | `false` | Quando `true`, sessoes PHP sao armazenadas no Memcached (necessario para balanceamento sem sticky session). Funciona apenas com SEI 5 |
+| `APP_MEMCACHED_HOST` | `memcached` | Hostname do serviço Memcached |
+| `APP_MEMCACHED_SESSION` | `false` | Quando `true`, sessões PHP são armazenadas no Memcached (necessário para balanceamento sem sticky session). Funciona apenas com SEI 5 |
 
 ---
 
 ## 10. Gerenciamento de Fontes via Git
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `APP_FONTES_GIT_PATH` | *(vazio)* | Caminho SSH do repositorio Git dos fontes. Ex: `git@github.com:supergovbr/super` |
-| `APP_FONTES_GIT_PRIVKEY_BASE64` | *(vazio)* | Chave privada SSH codificada em Base64 para clonar o repositorio |
-| `APP_FONTES_GITHUB_TOKEN` | *(vazio)* | Token GitHub para download de tarball. Tem precedencia sobre `APP_FONTES_GIT_PRIVKEY_BASE64` |
+| `APP_FONTES_GIT_PATH` | *(vazio)* | Caminho SSH do repositório Git dos fontes. Ex: `git@github.com:supergovbr/super` |
+| `APP_FONTES_GIT_PRIVKEY_BASE64` | *(vazio)* | Chave privada SSH codificada em Base64 para clonar o repositório |
+| `APP_FONTES_GITHUB_TOKEN` | *(vazio)* | Token GitHub para download de tarball. Tem precedência sobre `APP_FONTES_GIT_PRIVKEY_BASE64` |
 | `APP_FONTES_GIT_CHECKOUT` | *(vazio)* | Branch, tag ou commit para checkout. Ex: `main`, `4.0.3.3` |
 
 ---
 
-## 11. Conexao com Banco de Dados
+## 11. Conexão com Banco de Dados
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
 | `APP_DB_TIPO` | `MySql` | Tipo do banco. Valores: `MySql`, `SqlServer`, `Oracle`, `PostgreSql` |
 | `APP_DB_HOST` | `db` | Hostname do container de banco |
 | `APP_DB_PORTA` | `3306` | Porta do banco de dados |
 | `APP_DB_SEI_BASE` | `sei` | Nome da base de dados do SEI |
-| `APP_DB_SEI_USERNAME` | `sei_user` | Usuario do banco SEI |
+| `APP_DB_SEI_USERNAME` | `sei_user` | Usuário do banco SEI |
 | `APP_DB_SEI_PASSWORD` | `sei_user` | Senha do banco SEI |
 | `APP_DB_SIP_BASE` | `sip` | Nome da base de dados do SIP |
-| `APP_DB_SIP_USERNAME` | `sip_user` | Usuario do banco SIP |
+| `APP_DB_SIP_USERNAME` | `sip_user` | Usuário do banco SIP |
 | `APP_DB_SIP_PASSWORD` | `sip_user` | Senha do banco SIP |
-| `APP_DB_ROOT_USERNAME` | `root` | Usuario root/admin do banco |
+| `APP_DB_ROOT_USERNAME` | `root` | Usuário root/admin do banco |
 | `APP_DB_ROOT_PASSWORD` | `P@ssword` | Senha root/admin do banco |
 
 ---
 
 ## 12. Chaves de Acesso SEI/SIP
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `APP_SEI_CHAVE_ACESSO` | `7babf862e12b...6135dc` | Token de autenticacao inter-sistema do SEI |
-| `APP_SIP_CHAVE_ACESSO` | `d27791b89402...fb933` | Token de autenticacao inter-sistema do SIP |
+| `APP_SEI_CHAVE_ACESSO` | `7babf862e12b...6135dc` | Token de autenticação inter-sistema do SEI |
+| `APP_SIP_CHAVE_ACESSO` | `d27791b89402...fb933` | Token de autenticação inter-sistema do SIP |
 
 ---
 
-## 13. Configuracao do Solr
+## 13. Configuração do Solr
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
 | `APP_SOLR_URL` | `http://solr:8983/solr` | URL base do Solr |
 | `APP_SOLR_CORE_PROTOCOLOS` | `sei-protocolos` | Core para documentos de protocolo |
 | `APP_SOLR_TEMPO_COMMIT_PROTOCOLOS` | `300` | Intervalo de auto-commit (segundos) |
 | `APP_SOLR_CORE_BASECONHECIMENTO` | `sei-bases-conhecimento` | Core para base de conhecimento |
 | `APP_SOLR_TEMPO_COMMIT_BASECONHECIMENTO` | `60` | Intervalo de auto-commit (segundos) |
-| `APP_SOLR_CORE_PUBLICACOES` | `sei-publicacoes` | Core para publicacoes |
+| `APP_SOLR_CORE_PUBLICACOES` | `sei-publicacoes` | Core para publicações |
 | `APP_SOLR_TEMPO_COMMIT_PUBLICACOES` | `60` | Intervalo de auto-commit (segundos) |
 
 ---
 
-## 14. Configuracao de E-mail (SMTP)
+## 14. Configuração de E-mail (SMTP)
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `APP_MAIL_TIPO` | `2` | Metodo de envio. `1` = sendmail, `2` = SMTP |
+| `APP_MAIL_TIPO` | `2` | Método de envio. `1` = sendmail, `2` = SMTP |
 | `APP_MAIL_SERVIDOR` | `mail` | Servidor SMTP |
 | `APP_MAIL_PORTA` | `25` | Porta SMTP |
-| `APP_MAIL_CODIFICACAO` | `8bit` | Codificacao: `8bit`, `7bit`, `binary`, `base64`, `quoted-printable` |
-| `APP_MAIL_MAXDESTINATARIOS` | `999` | Maximo de destinatarios por e-mail |
-| `APP_MAIL_MAXTAMANHOANEXOSMB` | `999` | Tamanho maximo de anexos (MB) |
-| `APP_MAIL_SEGURANCA` | *(vazio)* | Seguranca SMTP: `/TLS`, `SSL`, ou vazio |
-| `APP_MAIL_AUTENTICAR` | *(vazio)* | Habilitar autenticacao SMTP |
-| `APP_MAIL_USUARIO` | *(vazio)* | Usuario SMTP |
+| `APP_MAIL_CODIFICACAO` | `8bit` | Codificação: `8bit`, `7bit`, `binary`, `base64`, `quoted-printable` |
+| `APP_MAIL_MAXDESTINATARIOS` | `999` | Máximo de destinatários por e-mail |
+| `APP_MAIL_MAXTAMANHOANEXOSMB` | `999` | Tamanho máximo de anexos (MB) |
+| `APP_MAIL_SEGURANCA` | *(vazio)* | Segurança SMTP: `/TLS`, `SSL`, ou vazio |
+| `APP_MAIL_AUTENTICAR` | *(vazio)* | Habilitar autenticação SMTP |
+| `APP_MAIL_USUARIO` | *(vazio)* | Usuário SMTP |
 | `APP_MAIL_SENHA` | *(vazio)* | Senha SMTP |
-| `APP_MAIL_PROTEGIDO` | *(vazio)* | E-mail de redirecionamento em dev. Quando definido, TODOS os e-mails sao desviados para este endereco |
+| `APP_MAIL_PROTEGIDO` | *(vazio)* | E-mail de redirecionamento em dev. Quando definido, TODOS os e-mails são desviados para este endereço |
 
 ---
 
 ## 15. OpenLDAP
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
 | `OPENLDAP_PRESENTE` | `false` | Habilitar OpenLDAP |
 | `OPENLDAP_ADMIN_PASSWORD` | `adminldap` | Senha admin LDAP. Login: `cn=admin,dc=pen,dc=gov,dc=br` |
-| `OPENLDAP_DESLIGAR_NO_ORGAO_0` | `false` | Forcar desativacao do LDAP para orgao 0 |
+| `OPENLDAP_DESLIGAR_NO_ORGAO_0` | `false` | Forçar desativação do LDAP para órgão 0 |
 
 ---
 
 ## 16. Protocolo Digital
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `SERVICO_PD_INSTALAR` | `false` | Instalar integracao Protocolo Digital |
-| `SERVICO_PD_SIGLA` | `GOV.BR` | Sigla do servico |
-| `SERVICO_PD_NOME` | `Protocolo.GOV.BR` | Nome do servico |
-| `SERVICO_PD_OPERACOES` | `3,2,15,0,1` | IDs das operacoes habilitadas |
+| `SERVICO_PD_INSTALAR` | `false` | Instalar integração Protocolo Digital |
+| `SERVICO_PD_SIGLA` | `GOV.BR` | Sigla do serviço |
+| `SERVICO_PD_NOME` | `Protocolo.GOV.BR` | Nome do serviço |
+| `SERVICO_PD_OPERACOES` | `3,2,15,0,1` | IDs das operações habilitadas |
 
 ---
 
-## 17. Credenciais Git para Modulos
+## 17. Credenciais Git para Módulos
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `GITUSER_REPO_MODULOS` | `dummy` | Usuario Git para repositorios de modulos privados |
-| `GITPASS_REPO_MODULOS` | `dummy` | Senha/token Git para repositorios de modulos |
+| `GITUSER_REPO_MODULOS` | `dummy` | Usuário Git para repositórios de módulos privados |
+| `GITPASS_REPO_MODULOS` | `dummy` | Senha/token Git para repositórios de módulos |
 
 ---
 
-## 18. Modulo Estatisticas
+## 18. Módulo Estatísticas
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `MODULO_ESTATISTICAS_INSTALAR` | `true` | Instalar modulo de estatisticas |
-| `MODULO_ESTATISTICAS_VERSAO` | `master` | Branch/tag do repositorio |
-| `MODULO_ESTATISTICAS_URL` | `https://estatistica.dev.processoeletronico.gov.br` | URL do servico de estatisticas |
-| `MODULO_ESTATISTICAS_SIGLA` | `SEIPUBLICO` | Sigla da credencial (publica para dev) |
+| `MODULO_ESTATISTICAS_INSTALAR` | `true` | Instalar módulo de estatísticas |
+| `MODULO_ESTATISTICAS_VERSAO` | `master` | Branch/tag do repositório |
+| `MODULO_ESTATISTICAS_URL` | `https://estatistica.dev.processoeletronico.gov.br` | URL do serviço de estatísticas |
+| `MODULO_ESTATISTICAS_SIGLA` | `SEIPUBLICO` | Sigla da credencial (pública para dev) |
 | `MODULO_ESTATISTICAS_CHAVE` | `seipublico` | Chave da credencial |
 
 ---
 
-## 19. Modulo REST / WSSEI
+## 19. Módulo REST / WSSEI
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `MODULO_REST_INSTALAR` | `false` | Instalar modulo REST |
+| `MODULO_REST_INSTALAR` | `false` | Instalar módulo REST |
 | `MODULO_REST_VERSAO` | `master` | Branch/tag |
-| `MODULO_REST_URL_NOTIFICACAO` | *(vazio)* | URL do servico de notificacoes push |
-| `MODULO_REST_ID_APP` | *(vazio)* | ID da aplicacao para push |
-| `MODULO_REST_CHAVE` | *(vazio)* | Chave de autorizacao |
+| `MODULO_REST_URL_NOTIFICACAO` | *(vazio)* | URL do serviço de notificações push |
+| `MODULO_REST_ID_APP` | *(vazio)* | ID da aplicação para push |
+| `MODULO_REST_CHAVE` | *(vazio)* | Chave de autorização |
 | `MODULO_REST_TOKEN_SECRET` | *(vazio)* | Secret para tokens |
 
 ---
 
-## 20. Modulo Gestao Documental
+## 20. Módulo Gestão Documental
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `MODULO_GESTAODOCUMENTAL_INSTALAR` | `false` | Instalar modulo de gestao documental |
+| `MODULO_GESTAODOCUMENTAL_INSTALAR` | `false` | Instalar módulo de gestão documental |
 | `MODULO_GESTAODOCUMENTAL_VERSAO` | `master` | Branch/tag |
 
 ---
 
-## 21. Modulo Resposta
+## 21. Módulo Resposta
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `MODULO_RESPOSTA_INSTALAR` | `false` | Instalar modulo de resposta |
+| `MODULO_RESPOSTA_INSTALAR` | `false` | Instalar módulo de resposta |
 | `MODULO_RESPOSTA_VERSAO` | `master` | Branch/tag |
 
 ---
 
-## 22. Modulo Login Unico (GOV.BR)
+## 22. Módulo Login Único (GOV.BR)
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `MODULO_LOGINUNICO_INSTALAR` | `false` | Instalar modulo Login Unico |
+| `MODULO_LOGINUNICO_INSTALAR` | `false` | Instalar módulo Login Único |
 | `MODULO_LOGINUNICO_VERSAO` | `master` | Branch/tag |
 | `MODULO_LOGINUNICO_CLIENTID` | `sistemas/homologacao/sei/controlador_externo` | Client ID OAuth2 |
 | `MODULO_LOGINUNICO_SECRET` | `XXXX` | Client Secret OAuth2 |
@@ -339,130 +339,130 @@ Todos os volumes devem ser criados mesmo quando nao utilizados. Volumes persiste
 | `MODULO_LOGINUNICO_REDIRECTURL` | `http://sei.xxx.nuvem.gov.br/.../controlador_loginunico.php` | URL de callback |
 | `MODULO_LOGINUNICO_URLLOGOUT` | `http://sei.xxx.nuvem.gov.br/.../logout.php` | URL de logout |
 | `MODULO_LOGINUNICO_SCOPE` | `openid+email+phone+profile+govbr_empresa+govbr_confiabilidades` | Escopos OAuth2 |
-| `MODULO_LOGINUNICO_URLSERVICOS` | `https://api.staging.acesso.gov.br/` | URL dos servicos GOV.BR |
-| `MODULO_LOGINUNICO_URLREVALIDACAO` | `https://oauth.staging.acesso.gov.br/v1/` | Endpoint de revalidacao |
-| `MODULO_LOGINUNICO_CIENTIDVALIDACAO` | `sei.xxx.nuvem.gov.br/validacaosenha` | Client ID para revalidacao |
-| `MODULO_LOGINUNICO_SECRETVALIDACAO` | `XXX` | Secret para revalidacao |
-| `MODULO_LOGINUNICO_ORGAO` | `0` | ID do orgao para integracao |
+| `MODULO_LOGINUNICO_URLSERVICOS` | `https://api.staging.acesso.gov.br/` | URL dos serviços GOV.BR |
+| `MODULO_LOGINUNICO_URLREVALIDACAO` | `https://oauth.staging.acesso.gov.br/v1/` | Endpoint de revalidação |
+| `MODULO_LOGINUNICO_CIENTIDVALIDACAO` | `sei.xxx.nuvem.gov.br/validacaosenha` | Client ID para revalidação |
+| `MODULO_LOGINUNICO_SECRETVALIDACAO` | `XXX` | Secret para revalidação |
+| `MODULO_LOGINUNICO_ORGAO` | `0` | ID do órgão para integração |
 
 ---
 
-## 23. Modulo Assinatura Avancada
+## 23. Módulo Assinatura Avançada
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `MODULO_ASSINATURA_INSTALAR` | `false` | Instalar modulo de assinatura eletronica |
+| `MODULO_ASSINATURA_INSTALAR` | `false` | Instalar módulo de assinatura eletrônica |
 | `MODULO_ASSINATURA_VERSAO` | `master` | Branch/tag |
 | `MODULO_ASSINATURA_URLPROVIDER` | `https://cas.staging.iti.br/oauth2.0` | Provedor OAuth2 para assinatura |
 | `MODULO_ASSINATURA_CLIENTID` | `assinaturaAvancadaXXX` | Client ID |
 | `MODULO_ASSINATURA_SECRET` | `XXX` | Client Secret |
-| `MODULO_ASSINATURA_VALIDAR_API_URL` | `https://informarurl` | URL da API de validacao |
-| `MODULO_ASSINATURA_VALIDAR_API_KEY` | `XXX` | Chave da API de validacao |
-| `MODULO_ASSINATURA_TOKEN_URL` | `XX` | URL para obtencao de token |
+| `MODULO_ASSINATURA_VALIDAR_API_URL` | `https://informarurl` | URL da API de validação |
+| `MODULO_ASSINATURA_VALIDAR_API_KEY` | `XXX` | Chave da API de validação |
+| `MODULO_ASSINATURA_TOKEN_URL` | `XX` | URL para obtenção de token |
 | `MODULO_ASSINATURA_TOKEN_SIGN_URL` | `XX` | URL para assinatura de token |
 | `MODULO_ASSINATURA_INTEGRA_ICP_URL` | `https://informar` | URL base ICP-Brasil |
 | `MODULO_ASSINATURA_INTEGRA_ICP_URL_CLEARINGS` | `/get-clearings` | Endpoint de clearings ICP |
 | `MODULO_ASSINATURA_INTEGRA_ICP_URL_ASSINAR` | `/sign` | Endpoint de assinatura ICP |
 | `MODULO_ASSINATURA_CLOUDPSC_URL` | `XXX` | URL do Cloud PSC |
-| `MODULO_ASSINATURA_CLOUDPSC_START_URL` | `XXX` | URL de inicio Cloud PSC |
+| `MODULO_ASSINATURA_CLOUDPSC_START_URL` | `XXX` | URL de início Cloud PSC |
 | `MODULO_ASSINATURA_CLOUDPSC_SIGN_URL` | `XXX` | URL de assinatura Cloud PSC |
 | `MODULO_ASSINATURA_API_KEY_ITYHY` | `XXX` | Chave API ITI/Hy |
 
 ---
 
-## 24. Modulo PEN / Barramento
+## 24. Módulo PEN / Barramento
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `MODULO_PEN_INSTALAR` | `false` | Instalar modulo PEN (tramitacao entre orgaos) |
+| `MODULO_PEN_INSTALAR` | `false` | Instalar módulo PEN (tramitação entre órgãos) |
 | `MODULO_PEN_VERSAO` | `master` | Branch/tag |
 | `MODULO_PEN_WEBSERVICE` | `https://homolog.api.processoeletronico.gov.br/.../v3/` | Endpoint SOAP do Barramento |
 | `MODULO_PEN_CERTIFICADO_SENHA` | `1234` | Senha do certificado PEM |
 | `MODULO_PEN_CERTIFICADO_BASE64` | *(base64 longo)* | Certificado PEM em Base64 (cert + chave privada) |
 | `MODULO_PEN_GEARMAN_IP` | *(vazio)* | IP do servidor Gearman |
 | `MODULO_PEN_GEARMAN_PORTA` | *(vazio)* | Porta do Gearman |
-| `MODULO_PEN_QTD_WORKER_PROC` | `1` | Numero de workers Gearman para PEN |
-| `MODULO_PEN_REPOSITORIO_ORIGEM` | *(vazio)* | Repositorio de origem (auto-config) |
+| `MODULO_PEN_QTD_WORKER_PROC` | `1` | Número de workers Gearman para PEN |
+| `MODULO_PEN_REPOSITORIO_ORIGEM` | *(vazio)* | Repositório de origem (auto-config) |
 | `MODULO_PEN_TIPO_PROCESSO_EXTERNO` | *(vazio)* | Tipo de processo para recebimentos externos |
 | `MODULO_PEN_UNIDADE_GERADORA` | *(vazio)* | Unidade geradora para processos recebidos |
-| `MODULO_PEN_UNIDADE_ASSOCIACAO_PEN` | *(vazio)* | ID da unidade PEN para associacao |
-| `MODULO_PEN_UNIDADE_ASSOCIACAO_SEI` | *(vazio)* | ID da unidade SEI para associacao |
+| `MODULO_PEN_UNIDADE_ASSOCIACAO_PEN` | *(vazio)* | ID da unidade PEN para associação |
+| `MODULO_PEN_UNIDADE_ASSOCIACAO_SEI` | *(vazio)* | ID da unidade SEI para associação |
 
 ---
 
-## 25. Modulo Peticionamento
+## 25. Módulo Peticionamento
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `MODULO_PETICIONAMENTO_INSTALAR` | `false` | Instalar modulo de peticionamento eletronico |
+| `MODULO_PETICIONAMENTO_INSTALAR` | `false` | Instalar módulo de peticionamento eletrônico |
 | `MODULO_PETICIONAMENTO_VERSAO` | `master` | Branch/tag |
-| `MODULO_PETICIONAMENTO_URL` | `https://github.com/anatelgovbr/mod-sei-peticionamento` | URL do repositorio |
+| `MODULO_PETICIONAMENTO_URL` | `https://github.com/anatelgovbr/mod-sei-peticionamento` | URL do repositório |
 
 ---
 
-## 26. Modulo Protocolo Integrado
+## 26. Módulo Protocolo Integrado
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `MODULO_PI_INSTALAR` | `false` | Instalar modulo Protocolo Integrado |
+| `MODULO_PI_INSTALAR` | `false` | Instalar módulo Protocolo Integrado |
 | `MODULO_PI_VERSAO` | `master` | Branch/tag |
 | `MODULO_PI_URL` | `https://protocolointegrado.preprod.nuvem.gov.br/.../integradorService?wsdl` | WSDL do web service |
-| `MODULO_PI_USUARIO` | `usuariodeconexaopi` | Usuario de conexao |
-| `MODULO_PI_SENHA` | `senhadeconexaoaopi` | Senha de conexao |
+| `MODULO_PI_USUARIO` | `usuariodeconexaopi` | Usuário de conexão |
+| `MODULO_PI_SENHA` | `senhadeconexaoaopi` | Senha de conexão |
 | `MODULO_PI_EMAIL` | `email@example.com` | E-mail de contato |
 
 ---
 
-## 27. Modulo INCOM (Imprensa Nacional)
+## 27. Módulo INCOM (Imprensa Nacional)
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `MODULO_INCOM_INSTALAR` | `false` | Instalar modulo INCOM |
+| `MODULO_INCOM_INSTALAR` | `false` | Instalar módulo INCOM |
 | `MODULO_INCOM_VERSAO` | `v1.0.4` | Branch/tag |
-| `MODULO_INCOM_VEICULOID` | `2` | ID do veiculo de publicacao |
-| `MODULO_INCOM_SERIEID` | `10` | ID da serie documental |
-| `MODULO_INCOM_SIORG` | `235876` | Codigo SIORG do orgao |
+| `MODULO_INCOM_VEICULOID` | `2` | ID do veículo de publicação |
+| `MODULO_INCOM_SERIEID` | `10` | ID da série documental |
+| `MODULO_INCOM_SIORG` | `235876` | Código SIORG do órgão |
 | `MODULO_INCOM_URLWS` | `https://seiwsincom2.in.gov.br/.../servicoIN?wsdl` | WSDL do web service INCOM |
-| `MODULO_INCOM_USERWS` | `XXX` | Usuario do web service |
+| `MODULO_INCOM_USERWS` | `XXX` | Usuário do web service |
 | `MODULO_INCOM_PASSWS` | `XXX` | Senha do web service |
-| `MODULO_INCOM_INCLUSAOPUBLICACAO` | `S` | Incluir publicacao (`S` = Sim) |
+| `MODULO_INCOM_INCLUSAOPUBLICACAO` | `S` | Incluir publicação (`S` = Sim) |
 
 ---
 
 ## 28. Kubernetes
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
 | `KUBERNETES_NAMESPACE` | `seins` | Namespace Kubernetes |
 | `KUBERNETES_PVC_STORAGECLASS` | `nfs-client` | Storage class para PVCs |
 | `KUBERNETES_RESOURCES_INFORMAR` | `true` | Incluir limites de recursos nos manifests |
 
-### Limites de Recursos por Servico
+### Limites de Recursos por Serviço
 
-| Servico | CPU Limit | Memory Limit | CPU Request | Memory Request |
+| Serviço | CPU Limit | Memory Limit | CPU Request | Memory Request |
 |---------|-----------|-------------|-------------|----------------|
 | Memcached | `500m` | `512Mi` | `500m` | `512Mi` |
 | JOD | `500m` | `512Mi` | `500m` | `512Mi` |
 | Solr | `500m` | `1Gi` | `500m` | `1Gi` |
 | Banco de Dados | `500m` | `1Gi` | `500m` | `1Gi` |
-| Aplicacao | `500m` | `1Gi` | `500m` | `1Gi` |
+| Aplicação | `500m` | `1Gi` | `500m` | `1Gi` |
 | Agendador | `500m` | `1Gi` | `500m` | `1Gi` |
 
-**Variaveis:** `KUBERNETES_LIMITS_CPU_{SERVICO}`, `KUBERNETES_LIMITS_MEMORY_{SERVICO}`, `KUBERNETES_REQUEST_CPU_{SERVICO}`, `KUBERNETES_REQUEST_MEMORY_{SERVICO}`
+**Variáveis:** `KUBERNETES_LIMITS_CPU_{SERVICO}`, `KUBERNETES_LIMITS_MEMORY_{SERVICO}`, `KUBERNETES_REQUEST_CPU_{SERVICO}`, `KUBERNETES_REQUEST_MEMORY_{SERVICO}`
 
 ---
 
-## 29. Variaveis de Build de Containers
+## 29. Variáveis de Build de Containers
 
 **Arquivo:** `containers/envcontainers.env.modelo`
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `DOCKER_CONTAINER_VERSAO_PRODUTO` | `3.6.11` | Versao do produto para tags das imagens |
+| `DOCKER_CONTAINER_VERSAO_PRODUTO` | `3.6.11` | Versão do produto para tags das imagens |
 
 ### Imagens Base
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
 | `IMAGEM_BASE_CENTOS` | `${DOCKER_REGISTRY}/base-centos7` | Imagem base CentOS |
 | `IMAGEM_BASE_ROCKY93` | `${DOCKER_REGISTRY}/base-rocky93` | Imagem base Rocky Linux |
@@ -480,42 +480,42 @@ Todos os volumes devem ser criados mesmo quando nao utilizados. Volumes persiste
 | `IMAGEM_BASE_OPENLDAP` | `${DOCKER_REGISTRY}/openldap-base` | Imagem base OpenLDAP |
 | `IMAGEM_BASE_PHPMEMCACHEDADMIN` | `${DOCKER_REGISTRY}/phpmemcachedadmin-base` | Imagem base admin Memcached |
 
-Cada variavel possui uma correspondente `*_VERSAO` com padrao `latest`.
+Cada variável possui uma correspondente `*_VERSAO` com padrão `latest`.
 
 ---
 
-## 30. Variaveis do Ambiente de Desenvolvimento
+## 30. Variáveis do Ambiente de Desenvolvimento
 
 **Arquivos:** `dev/envs/env-{banco}-{versao}.env`
 
-| Variavel | MySQL | PostgreSQL | Oracle | SQL Server | Descricao |
+| Variável | MySQL | PostgreSQL | Oracle | SQL Server | Descrição |
 |----------|-------|-----------|--------|------------|-----------|
-| `ENVIRONMENT_VERSION` | `3.6.7` | `3.6.7` | `3.6.7` | `3.6.7` | Versao do ambiente dev |
+| `ENVIRONMENT_VERSION` | `3.6.7` | `3.6.7` | `3.6.7` | `3.6.7` | Versão do ambiente dev |
 | `DATABASE_IMAGE` | `mysql8-sei50` | `postgres15-sei50` | `oracle11g-sei50` | `sqlserver2019-sei50` | Imagem do banco |
 | `DATABASE_TYPE` | `MySql` | `PostgreSql` | `Oracle` | `SqlServer` | Tipo do banco |
 | `DATABASE_HOST` | `mysql` | `postgres` | `oracle` | `sqlserver` | Hostname do banco |
 | `DATABASE_PORT` | `3306` | `5432` | `1521` | `1433` | Porta do banco |
-| `DATABASE_DATA_DIR` | `/var/lib/mysql` | `/var/lib/postgresql/data` | `/u01/app/oracle` | `/var/opt/mssql/data` | Diretorio de dados |
+| `DATABASE_DATA_DIR` | `/var/lib/mysql` | `/var/lib/postgresql/data` | `/u01/app/oracle` | `/var/opt/mssql/data` | Diretório de dados |
 | `APP_IMAGE` | `app-dev-php8` | `app-dev-php8` | `app-dev-php8` | `app-dev-php8` | Imagem do app |
 | `SOLR_IMAGE` | `solr9.6.1` | `solr9.6.1` | `solr9.6.1` | `solr9.6.1` | Imagem do Solr |
 | `JOD_IMAGE` | `jod4.4.8` | `jod4.4.8` | `jod4.4.8` | `jod4.4.8` | Imagem do JOD |
 
 ### Credenciais do Banco (Dev)
 
-| Variavel | MySQL/PostgreSQL | Oracle | Descricao |
+| Variável | MySQL/PostgreSQL | Oracle | Descrição |
 |----------|-----------------|--------|-----------|
-| `SEI_DATABASE_USER` | `sei_user` | `sei` | Usuario SEI |
-| `SIP_DATABASE_USER` | `sip_user` | `sip` | Usuario SIP |
-| `SEI_DATABASE_USER_SCRIPT` | `sei_user` / `postgres` | `sei` | Usuario para scripts de update |
+| `SEI_DATABASE_USER` | `sei_user` | `sei` | Usuário SEI |
+| `SIP_DATABASE_USER` | `sip_user` | `sip` | Usuário SIP |
+| `SEI_DATABASE_USER_SCRIPT` | `sei_user` / `postgres` | `sei` | Usuário para scripts de update |
 | `SEI_DATABASE_PASSWORD_SCRIPT` | `sei_user` / `P@ssword` | `sei_user` | Senha para scripts |
 
-### Variaveis de Runtime (docker-compose.yml dev)
+### Variáveis de Runtime (docker-compose.yml dev)
 
-| Variavel | Padrao | Descricao |
+| Variável | Padrão | Descrição |
 |----------|--------|-----------|
-| `SEI_PATH` | *(obrigatorio)* | Caminho do codigo-fonte no host, montado em `/opt/` |
-| `HOST_IP` | *(obrigatorio)* | IP do host para XDebug |
+| `SEI_PATH` | *(obrigatório)* | Caminho do código-fonte no host, montado em `/opt/` |
+| `HOST_IP` | *(obrigatório)* | IP do host para XDebug |
 | `HOST_URL` | `http://localhost:8000` | URL do SEI no ambiente dev |
 | `XDEBUG_CONFIG` | `idekey=default client_host=${HOST_IP} client_port=9003 discover_client_host=1` | Config do XDebug |
-| `XDEBUG_SESSION` | `default` | Nome da sessao/IDE key do XDebug |
+| `XDEBUG_SESSION` | `default` | Nome da sessão/IDE key do XDebug |
 | `XDEBUG_MODE` | `debug` | Modo do XDebug: `debug`, `profile`, `trace` |


### PR DESCRIPTION
Closes #153

## Resumo

- Cria pasta `docs/` com 8 arquivos de documentação técnica abrangente
- Documenta arquitetura, containers, variáveis de ambiente, orquestração, desenvolvimento e testes
- Consolida guias de uso dispersos em um guia unificado passo-a-passo
- Adiciona seção de documentação no README principal

## Conteúdo

| Arquivo | Descrição |
|---------|-----------|
| `docs/README.md` | Índice com links para toda a documentação |
| `docs/arquitetura.md` | Diagrama de serviços, hierarquia de imagens, fluxo de inicialização |
| `docs/containers.md` | Referência dos 44+ containers Docker por categoria |
| `docs/variaveis-ambiente.md` | Referência das 230+ variáveis de ambiente |
| `docs/orquestracao.md` | Docker Compose, Kubernetes, Makefile targets |
| `docs/desenvolvimento.md` | Setup dev, XDebug, troca de banco, troubleshooting |
| `docs/testes.md` | Níveis de teste, matriz, Selenium |
| `docs/guia-de-uso.md` | Guia unificado de instalação, configuração e uso |

## Motivação

O projeto não possui documentação técnica centralizada. As informações estão dispersas
em READMEs dentro de subpastas e não cobrem aspectos como variáveis de ambiente, arquitetura
e orquestração de forma completa.

## Test plan

- [ ] Verificar que todos os links internos entre documentos funcionam
- [ ] Validar que as variáveis de ambiente documentadas correspondem ao código-fonte
- [ ] Revisar conteúdo técnico para precisão