### PR TITLE
fix: migra template infra docker-compose para formato moderno com healthchecks

### DIFF
--- a/infra/Makefile
+++ b/infra/Makefile
@@ -223,9 +223,9 @@ ifeq ("$(MEMCACHEDADMIN_PRESENTE)",  "true")
 endif
 
 ifeq ("$(JOD_PRESENTE)",  "true")
-	@sed -i'' -e "s|#jod: #servicejod|jod: #servicejod|" orquestrators/docker-compose/docker-compose.yml
+	@sed -i'' -e "s|#jod: #servicejod|jod: #servicejod|g" orquestrators/docker-compose/docker-compose.yml
 	@sed -i'' -e "s|#    image: ${DOCKER_IMAGE_JOD} #servicejod|    image: ${DOCKER_IMAGE_JOD} #servicejod|" orquestrators/docker-compose/docker-compose.yml
-	@sed -i'' -e "s|#- jod:jod #servicejod|- jod:jod #servicejod|g" orquestrators/docker-compose/docker-compose.yml
+	@sed -i'' -e "s|#    condition: service_started #servicejod|    condition: service_started #servicejod|g" orquestrators/docker-compose/docker-compose.yml
 endif
 
 ifeq ("$(MAIL_CATCHER_PRESENTE)",  "true")
@@ -260,9 +260,11 @@ ifeq ("$(OPENLDAP_PRESENTE)",  "true")
 	@sed -i'' -e "s|#        traefik.http.routers.ldapadmin.tls: true #serviceldap|        traefik.http.routers.ldapadmin.tls: true #serviceldap|" orquestrators/docker-compose/docker-compose.yml
 	@sed -i'' -e "s|#        traefik.http.services.ldapadmin.loadbalancer.server.scheme: http #serviceldap|        traefik.http.services.ldapadmin.loadbalancer.server.scheme: http #serviceldap|" orquestrators/docker-compose/docker-compose.yml
 	@sed -i'' -e "s|#        traefik.http.services.ldapadmin.loadbalancer.server.port: 80 #serviceldap|        traefik.http.services.ldapadmin.loadbalancer.server.port: 80 #serviceldap|" orquestrators/docker-compose/docker-compose.yml
-	@sed -i'' -e "s|#    links: #serviceldap|    links: #serviceldap|" orquestrators/docker-compose/docker-compose.yml
-	@sed -i'' -e "s|#        - openldap:openldap #serviceldap|        - openldap:openldap #serviceldap|" orquestrators/docker-compose/docker-compose.yml
-	@sed -i'' -e "s|#openldap: #serviceldap|openldap: #serviceldap|" orquestrators/docker-compose/docker-compose.yml
+	@sed -i'' -e "s|#    depends_on: #serviceldap|    depends_on: #serviceldap|" orquestrators/docker-compose/docker-compose.yml
+	@sed -i'' -e "s|#        openldap: #serviceldap|        openldap: #serviceldap|" orquestrators/docker-compose/docker-compose.yml
+	@sed -i'' -e "s|#            condition: service_started #serviceldap|            condition: service_started #serviceldap|" orquestrators/docker-compose/docker-compose.yml
+	@sed -i'' -e "s|#openldap: #serviceldap|openldap: #serviceldap|g" orquestrators/docker-compose/docker-compose.yml
+	@sed -i'' -e "s|#    condition: service_started #serviceldap|    condition: service_started #serviceldap|g" orquestrators/docker-compose/docker-compose.yml
 	@sed -i'' -e "s|#    image: ${DOCKER_IMAGE_OPENLDAP} #serviceldap|    image: ${DOCKER_IMAGE_OPENLDAP} #serviceldap|" orquestrators/docker-compose/docker-compose.yml
 	@sed -i'' -e "s|#    environment: #serviceldap|    environment: #serviceldap|" orquestrators/docker-compose/docker-compose.yml
 	@sed -i'' -e "s|#        - KEEP_EXISTING_CONFIG=false #serviceldap|        - KEEP_EXISTING_CONFIG=false #serviceldap|" orquestrators/docker-compose/docker-compose.yml
@@ -279,8 +281,9 @@ ifeq ("$(OPENLDAP_PRESENTE)",  "true")
 	@sed -i'' -e "s|#        - LDAP_RFC2307BIS_SCHEMA=false #serviceldap|        - LDAP_RFC2307BIS_SCHEMA=false #serviceldap|" orquestrators/docker-compose/docker-compose.yml
 	@sed -i'' -e "s|#        - LDAP_SSL_HELPER_PREFIX=ldap #serviceldap|        - LDAP_SSL_HELPER_PREFIX=ldap #serviceldap|" orquestrators/docker-compose/docker-compose.yml
 	@sed -i'' -e "s|#        - LDAP_TLS=false #serviceldap|        - LDAP_TLS=false #serviceldap|" orquestrators/docker-compose/docker-compose.yml
-	@sed -i'' -e "s|#    volumes_from: #serviceldap|    volumes_from: #serviceldap|" orquestrators/docker-compose/docker-compose.yml
-	@sed -i'' -e "s|#        - storage-openldap #serviceldap|        - storage-openldap #serviceldap|" orquestrators/docker-compose/docker-compose.yml
+	@sed -i'' -e "s|#    volumes: #serviceldap|    volumes: #serviceldap|" orquestrators/docker-compose/docker-compose.yml
+	@sed -i'' -e "s|#        - ${VOLUME_OPENLDAP_SLAPD}:/etc/ldap/slapd.d #serviceldap|        - ${VOLUME_OPENLDAP_SLAPD}:/etc/ldap/slapd.d #serviceldap|" orquestrators/docker-compose/docker-compose.yml
+	@sed -i'' -e "s|#        - ${VOLUME_OPENLDAP_DB}:/var/lib/ldap #serviceldap|        - ${VOLUME_OPENLDAP_DB}:/var/lib/ldap #serviceldap|" orquestrators/docker-compose/docker-compose.yml
 
 endif
 
@@ -288,9 +291,9 @@ endif
 ifeq ("$(BALANCEADOR_PRESENTE)",  "true")
 	@sed -i'' -e "s|#balanceador: #servicebal|balanceador: #servicebal|" orquestrators/docker-compose/docker-compose.yml
 	@sed -i'' -e "s|#    image: ${DOCKER_IMAGE_BALANCEADOR} #servicebal|    image: ${DOCKER_IMAGE_BALANCEADOR} #servicebal|" orquestrators/docker-compose/docker-compose.yml
-	@sed -i'' -e "s|#    links: #servicebal|    links: #servicebal|" orquestrators/docker-compose/docker-compose.yml
-	@sed -i'' -e "s|#        - app #servicebal|        - app #servicebal|" orquestrators/docker-compose/docker-compose.yml
-	@sed -i'' -e "s|#        - solr #servicesolr #servicebal|        - solr #servicesolr #servicebal|" orquestrators/docker-compose/docker-compose.yml
+	@sed -i'' -e "s|#    depends_on: #servicebal|    depends_on: #servicebal|" orquestrators/docker-compose/docker-compose.yml
+	@sed -i'' -e "s|#        app: #servicebal|        app: #servicebal|" orquestrators/docker-compose/docker-compose.yml
+	@sed -i'' -e "s|#            condition: service_healthy #servicebal|            condition: service_healthy #servicebal|" orquestrators/docker-compose/docker-compose.yml
 	@sed -i'' -e "s|#    command: #servicebal|    command: #servicebal|" orquestrators/docker-compose/docker-compose.yml
 	@sed -i'' -e "s|#        - --log.level=DEBUG #servicebal|        - --log.level=DEBUG #servicebal|" orquestrators/docker-compose/docker-compose.yml
 	@sed -i'' -e "s|#        - --api.dashboard=true #servicebal|        - --api.dashboard=true #servicebal|" orquestrators/docker-compose/docker-compose.yml
@@ -333,9 +336,8 @@ ifeq ("$(BALANCEADOR_PRESENTE)",  "true")
 	@sed -i'' -e "s|#          - traefik.http.routers.myroothttps.tls=true #servicebal|          - traefik.http.routers.myroothttps.tls=true #servicebal|" orquestrators/docker-compose/docker-compose.yml
 	@sed -i'' -e "s|#          - traefik.http.routers.myroothttps.middlewares=myrootredirect #servicebal|          - traefik.http.routers.myroothttps.middlewares=myrootredirect #servicebal|" orquestrators/docker-compose/docker-compose.yml
 
-	@sed -i'' -e "s|#    volumes_from: #servicebal|    volumes_from: #servicebal|" orquestrators/docker-compose/docker-compose.yml
-	@sed -i'' -e "s|#        - storage-certs #servicebal|        - storage-certs #servicebal|" orquestrators/docker-compose/docker-compose.yml
 	@sed -i'' -e "s|#    volumes: #servicebal|    volumes: #servicebal|" orquestrators/docker-compose/docker-compose.yml
+	@sed -i'' -e "s|#        - ${VOLUME_CERTS_MOUNT}:/certs:rw #servicebal|        - ${VOLUME_CERTS_MOUNT}:/certs:rw #servicebal|" orquestrators/docker-compose/docker-compose.yml
 	@sed -i'' -e "s|#        - /var/run/docker.sock:/var/run/docker.sock #servicebal|        - /var/run/docker.sock:/var/run/docker.sock #servicebal|g" orquestrators/docker-compose/docker-compose.yml
 	@sed -i'' -e "s|nada|nada|" orquestrators/docker-compose/docker-compose.yml
 
@@ -369,21 +371,8 @@ endif
 
 
 
-ifeq ("$(DBADMIN_PRESENTE)",  "true")
-	@sed -i'' -e "s|#        - dbadmin #servicedbadmin #servicebal|        - dbadmin #servicedbadmin #servicebal|" orquestrators/docker-compose/docker-compose.yml
-endif
 
-ifeq ("$(MEMCACHEDADMIN_PRESENTE)",  "true")
-	@sed -i'' -e "s|#        - memcachedadmin #servicememcachedadmin #servicebal|        - memcachedadmin #servicememcachedadmin #servicebal|" orquestrators/docker-compose/docker-compose.yml
-endif
 
-ifeq ("$(MAIL_CATCHER_PRESENTE)",  "true")
-	@sed -i'' -e "s|#        - mail #servicemail #servicebal|        - mail #servicemail #servicebal|" orquestrators/docker-compose/docker-compose.yml
-endif
-
-ifeq ("$(OPENLDAP_PRESENTE)",  "true")
-	@sed -i'' -e "s|#        - ldapadmin #serviceldap #servicebal|        - ldapadmin #serviceldap #servicebal|" orquestrators/docker-compose/docker-compose.yml
-endif
 
 
 

--- a/infra/orquestrators/docker-compose/docker-compose-template.yml
+++ b/infra/orquestrators/docker-compose/docker-compose-template.yml
@@ -1,4 +1,3 @@
-version: '2'
 volumes:
     ${VOLUME_DB}:
         external: true
@@ -57,8 +56,9 @@ services:
     #        traefik.http.routers.ldapadmin.tls: true #serviceldap
     #        traefik.http.services.ldapadmin.loadbalancer.server.scheme: http #serviceldap
     #        traefik.http.services.ldapadmin.loadbalancer.server.port: 80 #serviceldap
-    #    links: #serviceldap
-    #        - openldap:openldap #serviceldap
+    #    depends_on: #serviceldap
+    #        openldap: #serviceldap
+    #            condition: service_started #serviceldap
     #openldap: #serviceldap
     #    image: ${DOCKER_IMAGE_OPENLDAP} #serviceldap
     #    environment: #serviceldap
@@ -76,8 +76,9 @@ services:
     #        - LDAP_RFC2307BIS_SCHEMA=false #serviceldap
     #        - LDAP_SSL_HELPER_PREFIX=ldap #serviceldap
     #        - LDAP_TLS=false #serviceldap
-    #    volumes_from: #serviceldap
-    #        - storage-openldap #serviceldap
+    #    volumes: #serviceldap
+    #        - ${VOLUME_OPENLDAP_SLAPD}:/etc/ldap/slapd.d #serviceldap
+    #        - ${VOLUME_OPENLDAP_DB}:/var/lib/ldap #serviceldap
 
     #jod: #servicejod
     #    image: ${DOCKER_IMAGE_JOD} #servicejod
@@ -99,6 +100,12 @@ services:
 
     memcached:
         image: ${DOCKER_IMAGE_MEMCACHED}
+        healthcheck:
+            test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/11211' || exit 1"]
+            interval: 30s
+            timeout: 10s
+            retries: 3
+            start_period: 10s
 
     #memcachedadmin: #servicememcachedadmin
     #    image: ${DOCKER_IMAGE_MEMCACHEDADMIN} #servicememcachedadmin
@@ -121,6 +128,12 @@ services:
             - SYS_NICE
         volumes:
             - ${VOLUME_DB}:${DB_DATA_DIRECTORY}
+        healthcheck:
+            test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/${APP_DB_PORTA}' || exit 1"]
+            interval: 15s
+            timeout: 10s
+            retries: 5
+            start_period: 60s
 
     #dbadmin: #servicedbadmin
     #    image: ${DOCKER_IMAGE_DBADMIN} #servicedbadmin
@@ -148,14 +161,23 @@ services:
           traefik.http.services.solr.loadbalancer.server.port: 8983
         volumes:
             - ${VOLUME_SOLR}:${SOLR_DATA_DIRECTORY}
+        healthcheck:
+            test: ["CMD-SHELL", "curl -sf http://localhost:8983/solr/ || exit 1"]
+            interval: 30s
+            timeout: 10s
+            retries: 3
+            start_period: 30s
 
 
     app-atualizador:
         image: ${DOCKER_IMAGE_APP}
         entrypoint: "/entrypoint-atualizador.sh"
-        volumes_from:
-            - storage-app
-            - storage-certs
+        volumes:
+            - ${VOLUME_ARQUIVOSEXTERNOS_MOUNT}:/sei/arquivos_externos_sei/:rw
+            - ${VOLUME_FONTES_MOUNT}:/opt:rw
+            - ${VOLUME_CONTROLADOR_INSTALACAO_MOUNT}:/sei/controlador-instalacoes
+            - ${VOLUME_CERTS_MOUNT}:/sei/certs
+            - ${VOLUME_CERTS_MOUNT}:/certs:rw
         labels:
             io.rancher.container.pull_image: always
             io.rancher.container.start_once: 'true'
@@ -292,18 +314,26 @@ services:
         - MODULO_INCOM_USERWS=${MODULO_INCOM_USERWS}
         - MODULO_INCOM_PASSWS=${MODULO_INCOM_PASSWS}
         - MODULO_INCOM_INCLUSAOPUBLICACAO=${MODULO_INCOM_INCLUSAOPUBLICACAO}
-        links:
-        - db:db
-        - memcached:memcached
-        - solr:solr #servicesolr
-        #- jod:jod #servicejod
-        #- openldap:openldap #serviceldap
+        depends_on:
+            db:
+                condition: service_healthy
+            memcached:
+                condition: service_healthy
+            solr:
+                condition: service_healthy
+            #jod: #servicejod
+            #    condition: service_started #servicejod
+            #openldap: #serviceldap
+            #    condition: service_started #serviceldap
     app-agendador:
         image: ${DOCKER_IMAGE_APP_AGENDADOR}
         entrypoint: "/entrypoint-agendador.sh"
-        volumes_from:
-            - storage-app
-            - storage-certs
+        volumes:
+            - ${VOLUME_ARQUIVOSEXTERNOS_MOUNT}:/sei/arquivos_externos_sei/:rw
+            - ${VOLUME_FONTES_MOUNT}:/opt:rw
+            - ${VOLUME_CONTROLADOR_INSTALACAO_MOUNT}:/sei/controlador-instalacoes
+            - ${VOLUME_CERTS_MOUNT}:/sei/certs
+            - ${VOLUME_CERTS_MOUNT}:/certs:rw
         labels:
             io.rancher.container.pull_image: always
             io.rancher.container.start_once: 'true'
@@ -440,21 +470,29 @@ services:
         - MODULO_INCOM_USERWS=${MODULO_INCOM_USERWS}
         - MODULO_INCOM_PASSWS=${MODULO_INCOM_PASSWS}
         - MODULO_INCOM_INCLUSAOPUBLICACAO=${MODULO_INCOM_INCLUSAOPUBLICACAO}
-        links:
-        - db:db
-        - memcached:memcached
-        - solr:solr #servicesolr
-        #- jod:jod #servicejod
-        #- openldap:openldap #serviceldap
+        depends_on:
+            db:
+                condition: service_healthy
+            memcached:
+                condition: service_healthy
+            solr:
+                condition: service_healthy
+            #jod: #servicejod
+            #    condition: service_started #servicejod
+            #openldap: #serviceldap
+            #    condition: service_started #serviceldap
     app:
         image: ${DOCKER_IMAGE_APP}
         entrypoint: "/entrypoint.sh"
         #ports:
         #    - ${APP_PORTA_80_MAP}
         #    - ${APP_PORTA_443_MAP}
-        volumes_from:
-            - storage-app
-            - storage-certs
+        volumes:
+            - ${VOLUME_ARQUIVOSEXTERNOS_MOUNT}:/sei/arquivos_externos_sei/:rw
+            - ${VOLUME_FONTES_MOUNT}:/opt:rw
+            - ${VOLUME_CONTROLADOR_INSTALACAO_MOUNT}:/sei/controlador-instalacoes
+            - ${VOLUME_CERTS_MOUNT}:/sei/certs
+            - ${VOLUME_CERTS_MOUNT}:/certs:rw
         labels:
           io.rancher.container.pull_image: always
           io.rancher.sidekicks: storage-arquivosexternos,storage-fontes,app-atualizador
@@ -599,22 +637,29 @@ services:
         - MODULO_INCOM_USERWS=${MODULO_INCOM_USERWS}
         - MODULO_INCOM_PASSWS=${MODULO_INCOM_PASSWS}
         - MODULO_INCOM_INCLUSAOPUBLICACAO=${MODULO_INCOM_INCLUSAOPUBLICACAO}
-        links:
-        - db:db
-        - memcached:memcachedcd
-        - solr:solr #servicesolr
-        #- jod:jod #servicejod
-        #- openldap:openldap #serviceldap
+        depends_on:
+            db:
+                condition: service_healthy
+            memcached:
+                condition: service_healthy
+            solr:
+                condition: service_healthy
+            #jod: #servicejod
+            #    condition: service_started #servicejod
+            #openldap: #serviceldap
+            #    condition: service_started #serviceldap
+        healthcheck:
+            test: ["CMD-SHELL", "curl -sfk ${APP_PROTOCOLO}://localhost/sei/ || exit 1"]
+            interval: 30s
+            timeout: 15s
+            retries: 5
+            start_period: 120s
 
     #balanceador: #servicebal
     #    image: ${DOCKER_IMAGE_BALANCEADOR} #servicebal
-    #    links: #servicebal
-    #        - app #servicebal
-    #        - solr #servicesolr #servicebal
-    #        - mail #servicemail #servicebal
-    #        - ldapadmin #serviceldap #servicebal
-    #        - memcachedadmin #servicememcachedadmin #servicebal
-    #        - dbadmin #servicedbadmin #servicebal
+    #    depends_on: #servicebal
+    #        app: #servicebal
+    #            condition: service_healthy #servicebal
     #    command: #servicebal
     #        - --log.level=DEBUG #servicebal
     #        - --api.dashboard=true #servicebal
@@ -662,9 +707,8 @@ services:
     #          - traefik.http.routers.myroothttps.tls=true #servicebal
     #          - traefik.http.routers.myroothttps.middlewares=myrootredirect #servicebal
 
-    #    volumes_from: #servicebal
-    #        - storage-certs #servicebal
     #    volumes: #servicebal
+    #        - ${VOLUME_CERTS_MOUNT}:/certs:rw #servicebal
     #        - /var/run/docker.sock:/var/run/docker.sock #servicebal
     #    ports: #servicebal
     #        - 80:80 #servicebal


### PR DESCRIPTION
## Summary
- Remove `version: '2'` obsoleto e construções deprecadas (`links:`, `volumes_from:`)
- Adiciona healthchecks aos 4 serviços sempre ativos (memcached, db, solr, app)
- Substitui `links:` por `depends_on:` com `condition: service_healthy/service_started`
- Substitui `volumes_from:` por `volumes:` explícitos nos serviços app
- Atualiza ~20 sed patterns no Makefile para corresponder à nova estrutura
- Simplifica dependências do balanceador (Traefik usa Docker labels, não links)

Closes #157

## Test plan
- [x] Validação YAML do template (9 serviços, estrutura válida)
- [x] Simulação sed: cenário base (sem opcionais)
- [x] Simulação sed: JOD habilitado (jod em depends_on dos 3 apps)
- [x] Simulação sed: OPENLDAP habilitado (ldapadmin + openldap + depends_on)
- [x] Simulação sed: Balanceador habilitado (depends_on app healthy + volumes)
- [x] Simulação sed: todos serviços (16 serviços, cadeia completa)
- [x] Zero referências residuais a `links:` ou `volumes_from:` no Makefile
- [ ] Teste em ambiente de infraestrutura real (requer configuração completa)