### PR TITLE
fix: corrige condição invertida na instalação do módulo peticionamento

### DIFF
--- a/containers/app-php8/app-ci-php8-agendador/assets/scripts-e-automatizadores/entrypoint-agendador.sh
+++ b/containers/app-php8/app-ci-php8-agendador/assets/scripts-e-automatizadores/entrypoint-agendador.sh
@@ -696,7 +696,7 @@ echo "*****************************************************"
 
 if [ "$MODULO_PETICIONAMENTO_INSTALAR" == "true" ]; then
 
-    if [ -f /sei/controlador-instalacoes/instalado-modulo-peticionamento.ok ]; then
+    if [ ! -f /sei/controlador-instalacoes/instalado-modulo-peticionamento.ok ]; then
 
         if [ -z "$MODULO_PETICIONAMENTO_VERSAO" ] || \
            [ -z "$MODULO_PETICIONAMENTO_URL" ]; then

--- a/containers/app-php8/app-ci-php8/assets/scripts-e-automatizadores/entrypoint-atualizador.sh
+++ b/containers/app-php8/app-ci-php8/assets/scripts-e-automatizadores/entrypoint-atualizador.sh
@@ -1111,7 +1111,7 @@ echo "*****************************************************"
 
 if [ "$MODULO_PETICIONAMENTO_INSTALAR" == "true" ]; then
 
-    if [ -f /sei/controlador-instalacoes/instalado-modulo-peticionamento.ok ]; then
+    if [ ! -f /sei/controlador-instalacoes/instalado-modulo-peticionamento.ok ]; then
 
         if [ -z "$MODULO_PETICIONAMENTO_VERSAO" ] || \
            [ -z "$MODULO_PETICIONAMENTO_URL" ]; then

--- a/containers/app-php8/app-ci-php8/assets/scripts-e-automatizadores/entrypoint.sh
+++ b/containers/app-php8/app-ci-php8/assets/scripts-e-automatizadores/entrypoint.sh
@@ -716,7 +716,7 @@ echo "*****************************************************"
 
 if [ "$MODULO_PETICIONAMENTO_INSTALAR" == "true" ]; then
 
-    if [ -f /sei/controlador-instalacoes/instalado-modulo-peticionamento.ok ]; then
+    if [ ! -f /sei/controlador-instalacoes/instalado-modulo-peticionamento.ok ]; then
 
         if [ -z "$MODULO_PETICIONAMENTO_VERSAO" ] || \
            [ -z "$MODULO_PETICIONAMENTO_URL" ]; then

--- a/containers/app/app-ci-agendador/assets/scripts-e-automatizadores/entrypoint-agendador.sh
+++ b/containers/app/app-ci-agendador/assets/scripts-e-automatizadores/entrypoint-agendador.sh
@@ -695,7 +695,7 @@ echo "*****************************************************"
 
 if [ "$MODULO_PETICIONAMENTO_INSTALAR" == "true" ]; then
 
-    if [ -f /sei/controlador-instalacoes/instalado-modulo-peticionamento.ok ]; then
+    if [ ! -f /sei/controlador-instalacoes/instalado-modulo-peticionamento.ok ]; then
 
         if [ -z "$MODULO_PETICIONAMENTO_VERSAO" ] || \
            [ -z "$MODULO_PETICIONAMENTO_URL" ]; then

--- a/containers/app/app-ci/assets/scripts-e-automatizadores/entrypoint-atualizador.sh
+++ b/containers/app/app-ci/assets/scripts-e-automatizadores/entrypoint-atualizador.sh
@@ -1090,7 +1090,7 @@ echo "*****************************************************"
 
 if [ "$MODULO_PETICIONAMENTO_INSTALAR" == "true" ]; then
 
-    if [ -f /sei/controlador-instalacoes/instalado-modulo-peticionamento.ok ]; then
+    if [ ! -f /sei/controlador-instalacoes/instalado-modulo-peticionamento.ok ]; then
 
         if [ -z "$MODULO_PETICIONAMENTO_VERSAO" ] || \
            [ -z "$MODULO_PETICIONAMENTO_URL" ]; then

--- a/containers/app/app-ci/assets/scripts-e-automatizadores/entrypoint.sh
+++ b/containers/app/app-ci/assets/scripts-e-automatizadores/entrypoint.sh
@@ -686,7 +686,7 @@ echo "*****************************************************"
 
 if [ "$MODULO_PETICIONAMENTO_INSTALAR" == "true" ]; then
 
-    if [ -f /sei/controlador-instalacoes/instalado-modulo-peticionamento.ok ]; then
+    if [ ! -f /sei/controlador-instalacoes/instalado-modulo-peticionamento.ok ]; then
 
         if [ -z "$MODULO_PETICIONAMENTO_VERSAO" ] || \
            [ -z "$MODULO_PETICIONAMENTO_URL" ]; then


### PR DESCRIPTION
## Summary
- Corrige condição invertida (`if [ -f` → `if [ ! -f`) na verificação do arquivo de controle `instalado-modulo-peticionamento.ok`
- Sem a correção, o módulo nunca é instalado na primeira execução pois a lógica entra no branch errado
- Correção aplicada nos 6 entrypoints afetados (PHP7 e PHP8)

Fixes #151

## Test plan
- [x] Verificação: zero ocorrências da condição invertida restantes
- [x] Verificação: 6 ocorrências da condição correta (`! -f`)
- [x] Padrão consistente com outros módulos (ex: mod-resposta usa `! -f`)